### PR TITLE
Annotate setup and draw methods with return types

### DIFF
--- a/src/native/cli/create.cr
+++ b/src/native/cli/create.cr
@@ -126,11 +126,12 @@ module Native::CLI
 
     private def create_app_template
       File.write("#{@path}/src/main.cr", <<-CR
+        require "native"
         class MyApp < Native::App
           @[Preserve]
           property count : Int32 = 0
 
-          def setup
+          def setup : Nil
             @label = UI::Text.new
             @label.text = "Tap: 0"
             @label.text_size = 24
@@ -154,7 +155,7 @@ module Native::CLI
             @label.text = "Tap: \#{@count}"
           end
 
-          def draw
+          def draw : Nil
             @root.draw(renderer)
           end
         end
@@ -219,9 +220,9 @@ module Native::CLI
           - Your Name <you@example.com>
 
         dependencies:
-          native:
+          native.cr:
             github: slick-lab/native.cr
-            version: ~> 0.1.0
+            version: ~> 0.0.97
 
         crystal: ">= 1.20.0"
 
@@ -384,6 +385,7 @@ module Native::CLI
       ios_dir = "#{@path}/ios"
       Dir.mkdir_p(ios_dir)
       Dir.mkdir_p("#{ios_dir}/NativeCr.xcodeproj")
+      Dir.mkdir_p("#{ios_dir}/Base.lproj")
 
       create_ios_pbxproj(ios_dir)
       create_ios_main_storyboard(ios_dir)


### PR DESCRIPTION
Added type annotations to the setup and draw methods to specify their return types as Nil, enhancing code clarity and type safety.


## Description

Please provide a summary of the changes and which issue is fixed.

Fixes #(issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI pipeline change

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have ran `crystal tool format` on my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [ ] I have added an entry to CHANGELOG.md

## Platform Impact

- [ ] Android
- [ ] iOS
- [ ] Both

## Testing Done

Describe the tests you ran to verify your changes.

## Screenshots (if appropriate)

## Additional Context

Add any other context about the pull request here.
