### PR TITLE
Add interpreter-based hot reload with Dear ImGui

### DIFF
--- a/spec/interpreter/nodes_spec.cr
+++ b/spec/interpreter/nodes_spec.cr
@@ -1,0 +1,243 @@
+require "./spec_helper"
+
+describe Native::Interpreter do
+  describe Native::Interpreter::UINode do
+    it "starts with no children" do
+      node = Native::Interpreter::TextViewNode.new("n1", "hello")
+      node.children.should be_empty
+    end
+
+    it "adds children" do
+      parent = Native::Interpreter::LinearLayoutNode.new("layout1")
+      child  = Native::Interpreter::TextViewNode.new("tv1", "hi")
+      parent.add_child(child)
+      parent.children.size.should eq(1)
+      parent.children.first.should be(child)
+    end
+
+    it "adds multiple children in order" do
+      layout = Native::Interpreter::LinearLayoutNode.new("l1")
+      3.times { |i| layout.add_child(Native::Interpreter::TextViewNode.new("tv#{i}", "text#{i}")) }
+      layout.children.size.should eq(3)
+    end
+
+    it "is visible by default" do
+      node = Native::Interpreter::ButtonNode.new("b1", "Click")
+      node.visible.should be_true
+    end
+
+    it "can be hidden" do
+      node = Native::Interpreter::TextViewNode.new("tv1", "text")
+      node.visible = false
+      node.visible.should be_false
+    end
+  end
+
+  describe Native::Interpreter::TextViewNode do
+    it "stores text" do
+      node = Native::Interpreter::TextViewNode.new("tv1", "Hello World")
+      node.text.should eq("Hello World")
+    end
+
+    it "has default text size 14" do
+      node = Native::Interpreter::TextViewNode.new("tv1", "text")
+      node.text_size.should eq(14)
+    end
+
+    it "allows setting text size" do
+      node = Native::Interpreter::TextViewNode.new("tv1", "text")
+      node.text_size = 24
+      node.text_size.should eq(24)
+    end
+
+    it "defaults to white color" do
+      node = Native::Interpreter::TextViewNode.new("tv1", "text")
+      r, g, b = node.color
+      r.should eq(1.0f32)
+      g.should eq(1.0f32)
+      b.should eq(1.0f32)
+    end
+
+    it "is not bold by default" do
+      node = Native::Interpreter::TextViewNode.new("tv1", "text")
+      node.bold.should be_false
+    end
+
+    it "can be set bold" do
+      node = Native::Interpreter::TextViewNode.new("tv1", "text")
+      node.bold = true
+      node.bold.should be_true
+    end
+  end
+
+  describe Native::Interpreter::ButtonNode do
+    it "stores label" do
+      node = Native::Interpreter::ButtonNode.new("b1", "Submit")
+      node.label.should eq("Submit")
+    end
+
+    it "is enabled by default" do
+      node = Native::Interpreter::ButtonNode.new("b1", "OK")
+      node.enabled.should be_true
+    end
+
+    it "has empty on_click_body by default" do
+      node = Native::Interpreter::ButtonNode.new("b1", "OK")
+      node.on_click_body.should be_empty
+    end
+
+    it "stores on_click body" do
+      node = Native::Interpreter::ButtonNode.new("b1", "OK")
+      node.on_click_body = "puts \"clicked\""
+      node.on_click_body.should eq("puts \"clicked\"")
+    end
+  end
+
+  describe Native::Interpreter::EditTextNode do
+    it "stores placeholder" do
+      node = Native::Interpreter::EditTextNode.new("et1", "Enter name...")
+      node.placeholder.should eq("Enter name...")
+    end
+
+    it "has empty value by default" do
+      node = Native::Interpreter::EditTextNode.new("et1", "hint")
+      node.value.should be_empty
+    end
+
+    it "is not multiline by default" do
+      node = Native::Interpreter::EditTextNode.new("et1", "hint")
+      node.multiline.should be_false
+    end
+  end
+
+  describe Native::Interpreter::CheckboxNode do
+    it "stores label" do
+      node = Native::Interpreter::CheckboxNode.new("cb1", "Remember me")
+      node.label.should eq("Remember me")
+    end
+
+    it "is unchecked by default" do
+      node = Native::Interpreter::CheckboxNode.new("cb1", "Option")
+      node.checked.should be_false
+    end
+
+    it "can be checked" do
+      node = Native::Interpreter::CheckboxNode.new("cb1", "Option")
+      node.checked = true
+      node.checked.should be_true
+    end
+  end
+
+  describe Native::Interpreter::SliderNode do
+    it "stores label, min, max" do
+      node = Native::Interpreter::SliderNode.new("s1", "Volume", 0.0f32, 1.0f32)
+      node.label.should eq("Volume")
+      node.min.should eq(0.0f32)
+      node.max.should eq(1.0f32)
+    end
+
+    it "has default value 0" do
+      node = Native::Interpreter::SliderNode.new("s1", "Speed", 0.0f32, 100.0f32)
+      node.value.should eq(0.0f32)
+    end
+
+    it "can set value" do
+      node = Native::Interpreter::SliderNode.new("s1", "Brightness", 0.0f32, 1.0f32)
+      node.value = 0.75f32
+      node.value.should eq(0.75f32)
+    end
+  end
+
+  describe Native::Interpreter::LinearLayoutNode do
+    it "defaults to vertical orientation" do
+      node = Native::Interpreter::LinearLayoutNode.new("l1")
+      node.orientation.should eq(Native::Interpreter::Orientation::Vertical)
+    end
+
+    it "can be horizontal" do
+      node = Native::Interpreter::LinearLayoutNode.new("l1", Native::Interpreter::Orientation::Horizontal)
+      node.orientation.should eq(Native::Interpreter::Orientation::Horizontal)
+    end
+
+    it "nests layouts" do
+      outer = Native::Interpreter::LinearLayoutNode.new("outer")
+      inner = Native::Interpreter::LinearLayoutNode.new("inner")
+      outer.add_child(inner)
+      outer.children.first.should be(inner)
+    end
+  end
+
+  describe Native::Interpreter::CardViewNode do
+    it "has empty title by default" do
+      node = Native::Interpreter::CardViewNode.new("c1")
+      node.title.should be_empty
+    end
+  end
+
+  describe Native::Interpreter::SeparatorNode do
+    it "creates with an id" do
+      node = Native::Interpreter::SeparatorNode.new("sep1")
+      node.id.should eq("sep1")
+      node.children.should be_empty
+    end
+  end
+
+  describe Native::Interpreter::SpacerNode do
+    it "has default height of 8" do
+      node = Native::Interpreter::SpacerNode.new("spacer1")
+      node.height.should eq(8)
+    end
+
+    it "accepts custom height" do
+      node = Native::Interpreter::SpacerNode.new("spacer1", 24)
+      node.height.should eq(24)
+    end
+  end
+
+  describe Native::Interpreter::ProgressBarNode do
+    it "has default value 0" do
+      node = Native::Interpreter::ProgressBarNode.new("pb1")
+      node.value.should eq(0.0f32)
+    end
+
+    it "stores value" do
+      node = Native::Interpreter::ProgressBarNode.new("pb1")
+      node.value = 0.5f32
+      node.value.should eq(0.5f32)
+    end
+  end
+
+  describe Native::Interpreter::ImageViewNode do
+    it "has empty src by default" do
+      node = Native::Interpreter::ImageViewNode.new("img1")
+      node.src.should be_empty
+    end
+
+    it "stores src" do
+      node = Native::Interpreter::ImageViewNode.new("img1", "avatar.png")
+      node.src.should eq("avatar.png")
+    end
+  end
+
+  describe Native::Interpreter::AppNode do
+    it "has no root by default" do
+      app = Native::Interpreter::AppNode.new
+      app.root.should be_nil
+    end
+
+    it "has no error by default" do
+      app = Native::Interpreter::AppNode.new
+      app.error_message.should be_nil
+    end
+
+    it "stores class name" do
+      app = Native::Interpreter::AppNode.new("MyApp")
+      app.class_name.should eq("MyApp")
+    end
+
+    it "has default title" do
+      app = Native::Interpreter::AppNode.new
+      app.title.should eq("native.cr Preview")
+    end
+  end
+end

--- a/spec/interpreter/parser_spec.cr
+++ b/spec/interpreter/parser_spec.cr
@@ -1,0 +1,527 @@
+require "./spec_helper"
+
+private def parse(source : String) : Native::Interpreter::AppNode
+  Native::Interpreter::Parser.new(source).parse
+end
+
+private def find_node(root : Native::Interpreter::UINode?, type : T.class) : T? forall T
+  return nil unless root
+  return root.as(T) if root.is_a?(T)
+  root.children.each do |child|
+    found = find_node(child, type)
+    return found if found
+  end
+  nil
+end
+
+private def all_nodes(root : Native::Interpreter::UINode?) : Array(Native::Interpreter::UINode)
+  return [] of Native::Interpreter::UINode unless root
+  [root] + root.children.flat_map { |c| all_nodes(c) }
+end
+
+describe Native::Interpreter::Parser do
+  describe "class name extraction" do
+    it "extracts simple class name" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+          end
+        end
+      CR
+      app = parse(source)
+      app.class_name.should eq("MyApp")
+    end
+
+    it "extracts class name without module prefix" do
+      source = <<-CR
+        class CounterApp < App
+          def setup
+          end
+        end
+      CR
+      app = parse(source)
+      app.class_name.should eq("CounterApp")
+    end
+
+    it "defaults class name when no class found" do
+      source = "def setup\nend"
+      app = parse(source)
+      app.class_name.should eq("App")
+    end
+
+    it "sets title from class name" do
+      source = <<-CR
+        class WeatherApp < Native::App
+          def setup
+          end
+        end
+      CR
+      app = parse(source)
+      app.title.should contain("WeatherApp")
+    end
+  end
+
+  describe "setup body extraction" do
+    it "returns error when no setup method" do
+      source = <<-CR
+        class MyApp < Native::App
+          def run
+          end
+        end
+      CR
+      app = parse(source)
+      app.error_message.should_not be_nil
+    end
+
+    it "parses empty setup without error" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+          end
+        end
+      CR
+      app = parse(source)
+      app.error_message.should be_nil
+    end
+  end
+
+  describe "widget parsing — TextView" do
+    it "parses TextView with string argument" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            label = TextView.new("Hello World")
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::TextViewNode)
+      node.should_not be_nil
+      node.not_nil!.text.should eq("Hello World")
+    end
+
+    it "parses Native::UI::TextView" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            t = Native::UI::TextView.new("Scoped")
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::TextViewNode)
+      node.should_not be_nil
+      node.not_nil!.text.should eq("Scoped")
+    end
+
+    it "parses empty TextView" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            spacer = TextView.new()
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::TextViewNode)
+      node.should_not be_nil
+    end
+  end
+
+  describe "widget parsing — Button" do
+    it "parses Button with label" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            btn = Button.new("Submit")
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::ButtonNode)
+      node.should_not be_nil
+      node.not_nil!.label.should eq("Submit")
+    end
+
+    it "captures on_click body" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            btn = Button.new("Go")
+            btn.on_click { puts "clicked" }
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::ButtonNode)
+      node.should_not be_nil
+      node.not_nil!.on_click_body.should eq("puts \"clicked\"")
+    end
+  end
+
+  describe "widget parsing — EditText" do
+    it "parses EditText with placeholder" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            input = EditText.new("Enter your name")
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::EditTextNode)
+      node.should_not be_nil
+      node.not_nil!.placeholder.should eq("Enter your name")
+    end
+
+    it "parses EditText without args" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            field = EditText.new()
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::EditTextNode)
+      node.should_not be_nil
+    end
+  end
+
+  describe "widget parsing — CheckBox" do
+    it "parses CheckBox with label" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            cb = CheckBox.new("Remember me")
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::CheckboxNode)
+      node.should_not be_nil
+      node.not_nil!.label.should eq("Remember me")
+    end
+
+    it "applies checked property" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            cb = CheckBox.new("Agree")
+            cb.checked = true
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::CheckboxNode)
+      node.should_not be_nil
+      node.not_nil!.checked.should be_true
+    end
+  end
+
+  describe "widget parsing — LinearLayout" do
+    it "parses vertical layout" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            layout = LinearLayout.new(:vertical)
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::LinearLayoutNode)
+      node.should_not be_nil
+      node.not_nil!.orientation.should eq(Native::Interpreter::Orientation::Vertical)
+    end
+
+    it "parses horizontal layout" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            row = LinearLayout.new(:horizontal)
+          end
+        end
+      CR
+      app = parse(source)
+      nodes = all_nodes(app.root).select { |n| n.is_a?(Native::Interpreter::LinearLayoutNode) }
+      h_nodes = nodes.select { |n| n.as(Native::Interpreter::LinearLayoutNode).orientation == Native::Interpreter::Orientation::Horizontal }
+      h_nodes.should_not be_empty
+    end
+
+    it "parses layout without args as vertical" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            l = LinearLayout.new()
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::LinearLayoutNode)
+      node.should_not be_nil
+      node.not_nil!.orientation.should eq(Native::Interpreter::Orientation::Vertical)
+    end
+  end
+
+  describe "widget parsing — CardView" do
+    it "parses CardView" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            card = CardView.new()
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::CardViewNode)
+      node.should_not be_nil
+    end
+  end
+
+  describe "widget parsing — ProgressBar" do
+    it "parses ProgressBar" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            bar = ProgressBar.new()
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::ProgressBarNode)
+      node.should_not be_nil
+    end
+
+    it "applies value property" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            bar = ProgressBar.new()
+            bar.value = 0.75
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::ProgressBarNode)
+      node.should_not be_nil
+      node.not_nil!.value.should be_close(0.75f32, 0.01f32)
+    end
+  end
+
+  describe "widget parsing — ImageView" do
+    it "parses ImageView with src" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            img = ImageView.new("avatar.png")
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::ImageViewNode)
+      node.should_not be_nil
+      node.not_nil!.src.should eq("avatar.png")
+    end
+  end
+
+  describe "property setters" do
+    it "applies text= to TextView" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            label = TextView.new("original")
+            label.text = "updated"
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::TextViewNode)
+      node.not_nil!.text.should eq("updated")
+    end
+
+    it "applies text_size= to TextView" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            title = TextView.new("Title")
+            title.text_size = 28
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::TextViewNode)
+      node.not_nil!.text_size.should eq(28)
+    end
+
+    it "applies placeholder= to EditText" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            field = EditText.new()
+            field.placeholder = "Type here..."
+          end
+        end
+      CR
+      app = parse(source)
+      node = find_node(app.root, Native::Interpreter::EditTextNode)
+      node.not_nil!.placeholder.should eq("Type here...")
+    end
+  end
+
+  describe "layout relationships" do
+    it "wires children via .add()" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            layout = LinearLayout.new(:vertical)
+            title  = TextView.new("Welcome")
+            btn    = Button.new("Start")
+            layout.add(title)
+            layout.add(btn)
+          end
+        end
+      CR
+      app = parse(source)
+      layout = find_node(app.root, Native::Interpreter::LinearLayoutNode)
+      layout.should_not be_nil
+      layout.not_nil!.children.size.should eq(2)
+      layout.not_nil!.children[0].should be_a(Native::Interpreter::TextViewNode)
+      layout.not_nil!.children[1].should be_a(Native::Interpreter::ButtonNode)
+    end
+
+    it "nests layouts" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            outer = LinearLayout.new(:vertical)
+            row   = LinearLayout.new(:horizontal)
+            btn1  = Button.new("A")
+            btn2  = Button.new("B")
+            row.add(btn1)
+            row.add(btn2)
+            outer.add(row)
+          end
+        end
+      CR
+      app = parse(source)
+      nodes = all_nodes(app.root)
+      layouts = nodes.select { |n| n.is_a?(Native::Interpreter::LinearLayoutNode) }
+      layouts.size.should be >= 2
+
+      h_layout = layouts.find { |n| n.as(Native::Interpreter::LinearLayoutNode).orientation == Native::Interpreter::Orientation::Horizontal }
+      h_layout.should_not be_nil
+      h_layout.not_nil!.children.size.should eq(2)
+    end
+
+    it "does not add a node as its own child" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            layout = LinearLayout.new(:vertical)
+            label  = TextView.new("hi")
+            layout.add(label)
+          end
+        end
+      CR
+      app = parse(source)
+      layout = find_node(app.root, Native::Interpreter::LinearLayoutNode)
+      layout.not_nil!.children.none? { |c| c == layout }.should be_true
+    end
+
+    it "wires children via .add_child()" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            card  = CardView.new()
+            label = TextView.new("Card content")
+            card.add_child(label)
+          end
+        end
+      CR
+      app = parse(source)
+      card = find_node(app.root, Native::Interpreter::CardViewNode)
+      card.should_not be_nil
+      card.not_nil!.children.size.should eq(1)
+    end
+  end
+
+  describe "multiple widgets" do
+    it "parses a full typical screen" do
+      source = <<-CR
+        class LoginApp < Native::App
+          def setup
+            layout   = LinearLayout.new(:vertical)
+            title    = TextView.new("Sign In")
+            email    = EditText.new("Email")
+            password = EditText.new("Password")
+            remember = CheckBox.new("Remember me")
+            submit   = Button.new("Login")
+            layout.add(title)
+            layout.add(email)
+            layout.add(password)
+            layout.add(remember)
+            layout.add(submit)
+          end
+        end
+      CR
+      app = parse(source)
+      app.error_message.should be_nil
+      app.class_name.should eq("LoginApp")
+
+      layout = find_node(app.root, Native::Interpreter::LinearLayoutNode)
+      layout.should_not be_nil
+      layout.not_nil!.children.size.should eq(5)
+
+      nodes = all_nodes(app.root)
+      nodes.any? { |n| n.is_a?(Native::Interpreter::TextViewNode) }.should be_true
+      nodes.any? { |n| n.is_a?(Native::Interpreter::EditTextNode) }.should be_true
+      nodes.any? { |n| n.is_a?(Native::Interpreter::CheckboxNode) }.should be_true
+      nodes.any? { |n| n.is_a?(Native::Interpreter::ButtonNode) }.should be_true
+    end
+
+    it "handles multiple top-level widgets gracefully" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            label = TextView.new("one")
+            btn   = Button.new("two")
+          end
+        end
+      CR
+      app = parse(source)
+      app.error_message.should be_nil
+      nodes = all_nodes(app.root)
+      nodes.any? { |n| n.is_a?(Native::Interpreter::TextViewNode) }.should be_true
+      nodes.any? { |n| n.is_a?(Native::Interpreter::ButtonNode) }.should be_true
+    end
+  end
+
+  describe "error handling" do
+    it "returns an app node even for empty source" do
+      app = parse("")
+      app.should_not be_nil
+    end
+
+    it "returns error for completely empty setup" do
+      source = "class A < Native::App\ndef setup\nend\nend"
+      app = parse(source)
+      app.should_not be_nil
+    end
+
+    it "ignores comment lines" do
+      source = <<-CR
+        class MyApp < Native::App
+          def setup
+            # This is a comment
+            label = TextView.new("Real")
+            # btn = Button.new("Commented out")
+          end
+        end
+      CR
+      app = parse(source)
+      nodes = all_nodes(app.root)
+      text_nodes = nodes.select { |n| n.is_a?(Native::Interpreter::TextViewNode) }
+      text_nodes.size.should eq(1)
+    end
+  end
+end

--- a/spec/interpreter/spec_helper.cr
+++ b/spec/interpreter/spec_helper.cr
@@ -1,0 +1,3 @@
+require "spec"
+require "../../src/native/interpreter/nodes"
+require "../../src/native/interpreter/parser"

--- a/src/native/cli/reload.cr
+++ b/src/native/cli/reload.cr
@@ -4,7 +4,13 @@ require "../core/process"
 
 module Native::CLI
   class ReloadCommand
+    INTERPRETER_BIN    = ".build/native_cr_interpreter"
+    INTERPRETER_SRC    = "src/native_interpreter_main.cr"
+    IMGUI_BUILD_SCRIPT = "src/native/interpreter/imgui/build.sh"
+    IMGUI_LIB          = "vendor/imgui/lib/libimgui_native.a"
+
     @entry_point : String = "src/main.cr"
+    @use_interpreter : Bool = true
 
     def initialize(args : Array(String))
       parse_args(args)
@@ -17,7 +23,11 @@ module Native::CLI
         when "-e", "--entry"
           @entry_point = args[i + 1] if i + 1 < args.size
           i += 2
+        when "--compile", "--no-interpreter"
+          @use_interpreter = false
+          i += 1
         else
+          @entry_point = args[i] if !args[i].starts_with?('-') && i == 0
           i += 1
         end
       end
@@ -29,9 +39,84 @@ module Native::CLI
         return
       end
 
+      if @use_interpreter
+        run_interpreter
+      else
+        run_compiler_based
+      end
+    end
+
+    private def run_interpreter
+      puts "[native.cr] Starting interpreter-based hot reload"
+      puts "[native.cr] No compilation needed — instant reload on save"
+      puts ""
+
+      ensure_imgui_built
+      ensure_interpreter_built
+
+      ::Process.exec(INTERPRETER_BIN, args: [@entry_point])
+    end
+
+    private def ensure_imgui_built
+      return if File.exists?(IMGUI_LIB)
+
+      puts "[native.cr] Building Dear ImGui library (first time only)..."
+      `chmod +x #{IMGUI_BUILD_SCRIPT}`
+      ok = system("bash #{IMGUI_BUILD_SCRIPT}")
+      unless ok
+        puts "[native.cr] Warning: ImGui build failed. Falling back to compile mode."
+        run_compiler_based
+        exit
+      end
+      puts ""
+    end
+
+    private def ensure_interpreter_built
+      return if File.exists?(INTERPRETER_BIN) && !interpreter_sources_newer?
+
+      puts "[native.cr] Building interpreter (one-time setup)..."
+      start = Time.monotonic
+
+      Dir.mkdir_p(".build")
+      ok = system(
+        "crystal build #{INTERPRETER_SRC} -o #{INTERPRETER_BIN} " \
+        "--error-trace 2>&1"
+      )
+
+      elapsed = (Time.monotonic - start).total_seconds
+      if ok
+        puts "[native.cr] Interpreter built in %.1fs" % elapsed
+      else
+        puts "[native.cr] Interpreter build failed. Falling back to compile mode."
+        run_compiler_based
+        exit
+      end
+      puts ""
+    end
+
+    private def interpreter_sources_newer? : Bool
+      return false unless File.exists?(INTERPRETER_BIN)
+      bin_time = File.info(INTERPRETER_BIN).modification_time
+      paths = ["src/native/interpreter", INTERPRETER_SRC]
+      paths.any? do |path|
+        if Dir.exists?(path)
+          Dir.glob("#{path}/**/*.cr").any? do |f|
+            File.info(f).modification_time > bin_time
+          end
+        elsif File.exists?(path)
+          File.info(path).modification_time > bin_time
+        else
+          false
+        end
+      end
+    rescue
+      false
+    end
+
+    private def run_compiler_based
+      puts "[native.cr] Falling back to compile-based hot reload"
       config = Native::Core::Process::Config.new
       config.entry_point = @entry_point
-
       manager = Native::Core::Process::Manager.new(config)
       manager.start
     end

--- a/src/native/interpreter/imgui/backend.cpp
+++ b/src/native/interpreter/imgui/backend.cpp
@@ -1,0 +1,201 @@
+#include "imgui.h"
+#include "imgui_impl_sdl2.h"
+#include "imgui_impl_opengl3.h"
+#include "backend.h"
+#include <SDL.h>
+#include <SDL_opengl.h>
+#include <cstring>
+#include <cstdio>
+
+static float s_font_scale = 1.0f;
+
+extern "C" {
+
+int imgui_backend_init(SDL_Window_ptr window, SDL_GLContext_ptr gl_context) {
+    return ImGui_ImplSDL2_InitForOpenGL(
+        (SDL_Window*)window,
+        gl_context
+    ) && ImGui_ImplOpenGL3_Init("#version 130");
+}
+
+void imgui_backend_shutdown(void) {
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplSDL2_Shutdown();
+}
+
+void imgui_backend_new_frame(SDL_Window_ptr window) {
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplSDL2_NewFrame();
+}
+
+void imgui_backend_render(ImDrawData_ptr draw_data) {
+    ImGui_ImplOpenGL3_RenderDrawData((ImDrawData*)draw_data);
+}
+
+int imgui_backend_process_event(SDL_Event_ptr event) {
+    return ImGui_ImplSDL2_ProcessEvent((SDL_Event*)event) ? 1 : 0;
+}
+
+void imgui_context_create(void) {
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+}
+
+void imgui_context_destroy(void) {
+    ImGui::DestroyContext();
+}
+
+void imgui_style_dark(void) {
+    ImGui::StyleColorsDark();
+    ImGuiStyle& style = ImGui::GetStyle();
+    style.WindowRounding    = 6.0f;
+    style.FrameRounding     = 4.0f;
+    style.ItemSpacing       = ImVec2(8, 6);
+    style.WindowPadding     = ImVec2(14, 14);
+    style.FramePadding      = ImVec2(8, 4);
+    style.ScrollbarRounding = 4.0f;
+    style.GrabRounding      = 4.0f;
+
+    ImVec4* colors = style.Colors;
+    colors[ImGuiCol_WindowBg]       = ImVec4(0.10f, 0.10f, 0.12f, 1.00f);
+    colors[ImGuiCol_Header]         = ImVec4(0.20f, 0.20f, 0.55f, 0.55f);
+    colors[ImGuiCol_HeaderHovered]  = ImVec4(0.26f, 0.26f, 0.70f, 0.80f);
+    colors[ImGuiCol_Button]         = ImVec4(0.20f, 0.35f, 0.75f, 0.75f);
+    colors[ImGuiCol_ButtonHovered]  = ImVec4(0.28f, 0.45f, 0.90f, 0.90f);
+    colors[ImGuiCol_ButtonActive]   = ImVec4(0.20f, 0.30f, 0.65f, 1.00f);
+    colors[ImGuiCol_FrameBg]        = ImVec4(0.16f, 0.16f, 0.20f, 1.00f);
+    colors[ImGuiCol_FrameBgHovered] = ImVec4(0.22f, 0.22f, 0.30f, 1.00f);
+    colors[ImGuiCol_SliderGrab]     = ImVec4(0.28f, 0.45f, 0.90f, 1.00f);
+    colors[ImGuiCol_CheckMark]      = ImVec4(0.28f, 0.56f, 1.00f, 1.00f);
+}
+
+void imgui_new_frame(void) {
+    ImGui::NewFrame();
+}
+
+void imgui_render(void) {
+    ImGui::Render();
+}
+
+void* imgui_get_draw_data(void) {
+    return (void*)ImGui::GetDrawData();
+}
+
+int imgui_begin(const char* name, int flags) {
+    return ImGui::Begin(name, nullptr, (ImGuiWindowFlags)flags) ? 1 : 0;
+}
+
+void imgui_end(void) {
+    ImGui::End();
+}
+
+void imgui_text(const char* text) {
+    ImGui::TextUnformatted(text);
+}
+
+void imgui_text_colored(float r, float g, float b, float a, const char* text) {
+    ImGui::TextColored(ImVec4(r, g, b, a), "%s", text);
+}
+
+void imgui_text_wrapped(const char* text) {
+    ImGui::TextWrapped("%s", text);
+}
+
+void imgui_separator(void) {
+    ImGui::Separator();
+}
+
+void imgui_spacing(void) {
+    ImGui::Spacing();
+}
+
+void imgui_dummy(float w, float h) {
+    ImGui::Dummy(ImVec2(w, h));
+}
+
+int imgui_button(const char* label, float w, float h) {
+    return ImGui::Button(label, ImVec2(w, h)) ? 1 : 0;
+}
+
+int imgui_input_text(const char* label, char* buf, int buf_size) {
+    return ImGui::InputText(label, buf, (size_t)buf_size) ? 1 : 0;
+}
+
+int imgui_input_text_multiline(const char* label, char* buf, int buf_size, float w, float h) {
+    return ImGui::InputTextMultiline(label, buf, (size_t)buf_size, ImVec2(w, h)) ? 1 : 0;
+}
+
+int imgui_checkbox(const char* label, int* v) {
+    bool b = (*v != 0);
+    bool changed = ImGui::Checkbox(label, &b);
+    *v = b ? 1 : 0;
+    return changed ? 1 : 0;
+}
+
+int imgui_slider_float(const char* label, float* v, float min, float max) {
+    return ImGui::SliderFloat(label, v, min, max) ? 1 : 0;
+}
+
+void imgui_progress_bar(float fraction, float w, float h, const char* overlay) {
+    ImGui::ProgressBar(fraction, ImVec2(w, h), overlay && overlay[0] ? overlay : nullptr);
+}
+
+void imgui_set_next_window_pos(float x, float y) {
+    ImGui::SetNextWindowPos(ImVec2(x, y), ImGuiCond_Always);
+}
+
+void imgui_set_next_window_size(float w, float h) {
+    ImGui::SetNextWindowSize(ImVec2(w, h), ImGuiCond_Always);
+}
+
+void imgui_push_font_scale(float scale) {
+    s_font_scale = scale;
+    ImGui::SetWindowFontScale(scale);
+}
+
+void imgui_pop_font_scale(void) {
+    ImGui::SetWindowFontScale(1.0f);
+    s_font_scale = 1.0f;
+}
+
+void imgui_push_style_color(int idx, float r, float g, float b, float a) {
+    ImGui::PushStyleColor((ImGuiCol)idx, ImVec4(r, g, b, a));
+}
+
+void imgui_pop_style_color(int count) {
+    ImGui::PopStyleColor(count);
+}
+
+void imgui_push_style_var_float(int idx, float val) {
+    ImGui::PushStyleVar((ImGuiStyleVar)idx, val);
+}
+
+void imgui_pop_style_var(int count) {
+    ImGui::PopStyleVar(count);
+}
+
+int imgui_begin_child(const char* id, float w, float h, int border, int flags) {
+    return ImGui::BeginChild(id, ImVec2(w, h), border != 0, (ImGuiWindowFlags)flags) ? 1 : 0;
+}
+
+void imgui_end_child(void) {
+    ImGui::EndChild();
+}
+
+void imgui_same_line(float offset_from_start_x, float spacing) {
+    ImGui::SameLine(offset_from_start_x, spacing);
+}
+
+void imgui_get_display_size(float* w, float* h) {
+    ImGuiIO& io = ImGui::GetIO();
+    *w = io.DisplaySize.x;
+    *h = io.DisplaySize.y;
+}
+
+float imgui_get_font_size(void) {
+    return ImGui::GetFontSize();
+}
+
+} // extern "C"

--- a/src/native/interpreter/imgui/backend.h
+++ b/src/native/interpreter/imgui/backend.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* SDL_Window_ptr;
+typedef void* SDL_GLContext_ptr;
+typedef void* ImDrawData_ptr;
+typedef void* SDL_Event_ptr;
+
+int  imgui_backend_init(SDL_Window_ptr window, SDL_GLContext_ptr gl_context);
+void imgui_backend_shutdown(void);
+void imgui_backend_new_frame(SDL_Window_ptr window);
+void imgui_backend_render(ImDrawData_ptr draw_data);
+int  imgui_backend_process_event(SDL_Event_ptr event);
+
+void imgui_context_create(void);
+void imgui_context_destroy(void);
+void imgui_style_dark(void);
+void imgui_new_frame(void);
+void imgui_render(void);
+void* imgui_get_draw_data(void);
+
+int   imgui_begin(const char* name, int flags);
+void  imgui_end(void);
+void  imgui_text(const char* text);
+void  imgui_text_colored(float r, float g, float b, float a, const char* text);
+void  imgui_text_wrapped(const char* text);
+void  imgui_separator(void);
+void  imgui_spacing(void);
+void  imgui_dummy(float w, float h);
+int   imgui_button(const char* label, float w, float h);
+int   imgui_input_text(const char* label, char* buf, int buf_size);
+int   imgui_input_text_multiline(const char* label, char* buf, int buf_size, float w, float h);
+int   imgui_checkbox(const char* label, int* v);
+int   imgui_slider_float(const char* label, float* v, float min, float max);
+void  imgui_progress_bar(float fraction, float w, float h, const char* overlay);
+void  imgui_set_next_window_pos(float x, float y);
+void  imgui_set_next_window_size(float w, float h);
+void  imgui_push_font_scale(float scale);
+void  imgui_pop_font_scale(void);
+void  imgui_push_style_color(int idx, float r, float g, float b, float a);
+void  imgui_pop_style_color(int count);
+void  imgui_push_style_var_float(int idx, float val);
+void  imgui_pop_style_var(int count);
+int   imgui_begin_child(const char* id, float w, float h, int border, int flags);
+void  imgui_end_child(void);
+void  imgui_same_line(float offset_from_start_x, float spacing);
+void  imgui_get_display_size(float* w, float* h);
+float imgui_get_font_size(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/native/interpreter/imgui/build.sh
+++ b/src/native/interpreter/imgui/build.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Downloads and compiles Dear ImGui + cimgui with SDL2 + OpenGL3 backends
+# Output: vendor/imgui/lib/libimgui_native.a + headers
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+VENDOR_DIR="$ROOT_DIR/vendor/imgui"
+SRC_DIR="$VENDOR_DIR/src"
+LIB_DIR="$VENDOR_DIR/lib"
+INC_DIR="$VENDOR_DIR/include"
+
+if [ -f "$LIB_DIR/libimgui_native.a" ]; then
+  echo "[imgui] Already built, skipping."
+  exit 0
+fi
+
+mkdir -p "$SRC_DIR" "$LIB_DIR" "$INC_DIR"
+
+IMGUI_VERSION="1.90.9"
+IMGUI_URL="https://github.com/ocornut/imgui/archive/refs/tags/v${IMGUI_VERSION}.tar.gz"
+
+echo "[imgui] Downloading Dear ImGui v${IMGUI_VERSION}..."
+curl -L "$IMGUI_URL" -o "$SRC_DIR/imgui.tar.gz"
+tar -xf "$SRC_DIR/imgui.tar.gz" -C "$SRC_DIR" --strip-components=1
+rm "$SRC_DIR/imgui.tar.gz"
+
+echo "[imgui] Locating SDL2..."
+SDL2_CFLAGS=$(sdl2-config --cflags 2>/dev/null || echo "-I/usr/include/SDL2")
+SDL2_LIBS=$(sdl2-config --libs 2>/dev/null || echo "-lSDL2")
+
+echo "[imgui] SDL2 CFLAGS: $SDL2_CFLAGS"
+
+echo "[imgui] Compiling imgui core..."
+CXX_FLAGS="-std=c++17 -O2 -fPIC $SDL2_CFLAGS \
+  -I$SRC_DIR \
+  -I$SRC_DIR/backends \
+  -DIMGUI_IMPL_OPENGL_LOADER_CUSTOM"
+
+OBJECTS=()
+
+# Core ImGui
+g++ $CXX_FLAGS -c "$SRC_DIR/imgui.cpp" -o "$SRC_DIR/imgui.o"
+g++ $CXX_FLAGS -c "$SRC_DIR/imgui_draw.cpp" -o "$SRC_DIR/imgui_draw.o"
+g++ $CXX_FLAGS -c "$SRC_DIR/imgui_tables.cpp" -o "$SRC_DIR/imgui_tables.o"
+g++ $CXX_FLAGS -c "$SRC_DIR/imgui_widgets.cpp" -o "$SRC_DIR/imgui_widgets.o"
+g++ $CXX_FLAGS -c "$SRC_DIR/imgui_demo.cpp" -o "$SRC_DIR/imgui_demo.o"
+
+# Backends
+g++ $CXX_FLAGS -c "$SRC_DIR/backends/imgui_impl_sdl2.cpp" -o "$SRC_DIR/imgui_impl_sdl2.o"
+g++ $CXX_FLAGS -c "$SRC_DIR/backends/imgui_impl_opengl3.cpp" -o "$SRC_DIR/imgui_impl_opengl3.o"
+
+# Our C backend wrapper
+g++ $CXX_FLAGS -c "$SCRIPT_DIR/backend.cpp" -o "$SRC_DIR/backend.o"
+
+echo "[imgui] Archiving static library..."
+ar rcs "$LIB_DIR/libimgui_native.a" \
+  "$SRC_DIR/imgui.o" \
+  "$SRC_DIR/imgui_draw.o" \
+  "$SRC_DIR/imgui_tables.o" \
+  "$SRC_DIR/imgui_widgets.o" \
+  "$SRC_DIR/imgui_demo.o" \
+  "$SRC_DIR/imgui_impl_sdl2.o" \
+  "$SRC_DIR/imgui_impl_opengl3.o" \
+  "$SRC_DIR/backend.o"
+
+echo "[imgui] Copying headers..."
+cp "$SRC_DIR/imgui.h" "$INC_DIR/"
+cp "$SRC_DIR/imgui_internal.h" "$INC_DIR/"
+cp "$SRC_DIR/imconfig.h" "$INC_DIR/"
+cp "$SRC_DIR/imstb_rectpack.h" "$INC_DIR/"
+cp "$SRC_DIR/imstb_textedit.h" "$INC_DIR/"
+cp "$SRC_DIR/imstb_truetype.h" "$INC_DIR/"
+cp "$SRC_DIR/backends/imgui_impl_sdl2.h" "$INC_DIR/"
+cp "$SRC_DIR/backends/imgui_impl_opengl3.h" "$INC_DIR/"
+cp "$SCRIPT_DIR/backend.h" "$INC_DIR/"
+
+echo "[imgui] Build complete! Library at: $LIB_DIR/libimgui_native.a"

--- a/src/native/interpreter/imgui/lib_gl.cr
+++ b/src/native/interpreter/imgui/lib_gl.cr
@@ -1,0 +1,23 @@
+@[Link("GL")]
+lib LibGL
+  GL_COLOR_BUFFER_BIT = 0x00004000
+  GL_DEPTH_BUFFER_BIT = 0x00000100
+
+  fun glClearColor(red : Float32, green : Float32, blue : Float32, alpha : Float32)
+  fun glClear(mask : UInt32)
+  fun glViewport(x : Int32, y : Int32, width : Int32, height : Int32)
+end
+
+module GL
+  def self.clear_color(r : Float32, g : Float32, b : Float32, a : Float32 = 1.0f32)
+    LibGL.glClearColor(r, g, b, a)
+  end
+
+  def self.clear
+    LibGL.glClear(LibGL::GL_COLOR_BUFFER_BIT | LibGL::GL_DEPTH_BUFFER_BIT)
+  end
+
+  def self.viewport(x : Int32, y : Int32, w : Int32, h : Int32)
+    LibGL.glViewport(x, y, w, h)
+  end
+end

--- a/src/native/interpreter/imgui/lib_imgui.cr
+++ b/src/native/interpreter/imgui/lib_imgui.cr
@@ -1,0 +1,237 @@
+@[Link(ldflags: "-L#{__DIR__}/../../../../vendor/imgui/lib -limgui_native -lSDL2 -lGL -ldl -lpthread -lstdc++")]
+lib LibImGui
+  fun imgui_context_create = "imgui_context_create"()
+  fun imgui_context_destroy = "imgui_context_destroy"()
+  fun imgui_style_dark = "imgui_style_dark"()
+  fun imgui_new_frame = "imgui_new_frame"()
+  fun imgui_render = "imgui_render"()
+  fun imgui_get_draw_data = "imgui_get_draw_data"() : Void*
+
+  fun imgui_begin = "imgui_begin"(name : UInt8*, flags : Int32) : Int32
+  fun imgui_end = "imgui_end"()
+  fun imgui_text = "imgui_text"(text : UInt8*)
+  fun imgui_text_colored = "imgui_text_colored"(r : Float32, g : Float32, b : Float32, a : Float32, text : UInt8*)
+  fun imgui_text_wrapped = "imgui_text_wrapped"(text : UInt8*)
+  fun imgui_separator = "imgui_separator"()
+  fun imgui_spacing = "imgui_spacing"()
+  fun imgui_dummy = "imgui_dummy"(w : Float32, h : Float32)
+  fun imgui_button = "imgui_button"(label : UInt8*, w : Float32, h : Float32) : Int32
+  fun imgui_input_text = "imgui_input_text"(label : UInt8*, buf : UInt8*, buf_size : Int32) : Int32
+  fun imgui_input_text_multiline = "imgui_input_text_multiline"(label : UInt8*, buf : UInt8*, buf_size : Int32, w : Float32, h : Float32) : Int32
+  fun imgui_checkbox = "imgui_checkbox"(label : UInt8*, v : Int32*) : Int32
+  fun imgui_slider_float = "imgui_slider_float"(label : UInt8*, v : Float32*, min : Float32, max : Float32) : Int32
+  fun imgui_progress_bar = "imgui_progress_bar"(fraction : Float32, w : Float32, h : Float32, overlay : UInt8*)
+  fun imgui_set_next_window_pos = "imgui_set_next_window_pos"(x : Float32, y : Float32)
+  fun imgui_set_next_window_size = "imgui_set_next_window_size"(w : Float32, h : Float32)
+  fun imgui_push_font_scale = "imgui_push_font_scale"(scale : Float32)
+  fun imgui_pop_font_scale = "imgui_pop_font_scale"()
+  fun imgui_push_style_color = "imgui_push_style_color"(idx : Int32, r : Float32, g : Float32, b : Float32, a : Float32)
+  fun imgui_pop_style_color = "imgui_pop_style_color"(count : Int32)
+  fun imgui_push_style_var_float = "imgui_push_style_var_float"(idx : Int32, val : Float32)
+  fun imgui_pop_style_var = "imgui_pop_style_var"(count : Int32)
+  fun imgui_begin_child = "imgui_begin_child"(id : UInt8*, w : Float32, h : Float32, border : Int32, flags : Int32) : Int32
+  fun imgui_end_child = "imgui_end_child"()
+  fun imgui_same_line = "imgui_same_line"(offset : Float32, spacing : Float32)
+  fun imgui_get_display_size = "imgui_get_display_size"(w : Float32*, h : Float32*)
+  fun imgui_get_font_size = "imgui_get_font_size"() : Float32
+
+  fun imgui_backend_init = "imgui_backend_init"(window : Void*, gl_ctx : Void*) : Int32
+  fun imgui_backend_shutdown = "imgui_backend_shutdown"()
+  fun imgui_backend_new_frame = "imgui_backend_new_frame"(window : Void*)
+  fun imgui_backend_render = "imgui_backend_render"(draw_data : Void*)
+  fun imgui_backend_process_event = "imgui_backend_process_event"(event : Void*) : Int32
+end
+
+module ImGui
+  WINDOW_NO_TITLE_BAR  = 1 << 0
+  WINDOW_NO_RESIZE     = 1 << 1
+  WINDOW_NO_MOVE       = 1 << 2
+  WINDOW_NO_SCROLLBAR  = 1 << 3
+  WINDOW_NO_SCROLL_WITH_MOUSE = 1 << 4
+  WINDOW_NO_COLLAPSE   = 1 << 5
+  WINDOW_ALWAYS_AUTO_RESIZE = 1 << 6
+  WINDOW_NO_BACKGROUND = 1 << 7
+  WINDOW_NO_SAVED_SETTINGS = 1 << 8
+  WINDOW_NO_MOUSE_INPUTS = 1 << 9
+  WINDOW_MENU_BAR      = 1 << 10
+  WINDOW_HORIZONTAL_SCROLLBAR = 1 << 11
+  WINDOW_NO_FOCUS_ON_APPEARING = 1 << 12
+  WINDOW_NO_BRING_TO_DISPLAY_FRONT = 1 << 13
+  WINDOW_ALWAYS_VERTICAL_SCROLLBAR = 1 << 14
+  WINDOW_ALWAYS_HORIZONTAL_SCROLLBAR = 1 << 15
+
+  COL_TEXT              = 0
+  COL_WINDOW_BG         = 2
+  COL_FRAME_BG          = 7
+  COL_FRAME_BG_HOVERED  = 8
+  COL_TITLE_BG_ACTIVE   = 12
+  COL_BUTTON            = 21
+  COL_BUTTON_HOVERED    = 22
+  COL_BUTTON_ACTIVE     = 23
+  COL_SEPARATOR         = 27
+  COL_SLIDER_GRAB       = 33
+
+  STYLE_VAR_WINDOW_ROUNDING = 3
+  STYLE_VAR_FRAME_ROUNDING  = 5
+  STYLE_VAR_ITEM_SPACING    = 13
+  STYLE_VAR_FRAME_PADDING   = 12
+
+  def self.create_context
+    LibImGui.imgui_context_create
+  end
+
+  def self.destroy_context
+    LibImGui.imgui_context_destroy
+  end
+
+  def self.style_dark
+    LibImGui.imgui_style_dark
+  end
+
+  def self.new_frame
+    LibImGui.imgui_new_frame
+  end
+
+  def self.render
+    LibImGui.imgui_render
+  end
+
+  def self.get_draw_data : Void*
+    LibImGui.imgui_get_draw_data
+  end
+
+  def self.begin(name : String, flags : Int32 = 0) : Bool
+    LibImGui.imgui_begin(name, flags) != 0
+  end
+
+  def self.end
+    LibImGui.imgui_end
+  end
+
+  def self.text(str : String)
+    LibImGui.imgui_text(str)
+  end
+
+  def self.text_colored(r : Float32, g : Float32, b : Float32, a : Float32, str : String)
+    LibImGui.imgui_text_colored(r, g, b, a, str)
+  end
+
+  def self.text_wrapped(str : String)
+    LibImGui.imgui_text_wrapped(str)
+  end
+
+  def self.separator
+    LibImGui.imgui_separator
+  end
+
+  def self.spacing
+    LibImGui.imgui_spacing
+  end
+
+  def self.dummy(w : Float32, h : Float32)
+    LibImGui.imgui_dummy(w, h)
+  end
+
+  def self.button(label : String, w : Float32 = 0.0f32, h : Float32 = 0.0f32) : Bool
+    LibImGui.imgui_button(label, w, h) != 0
+  end
+
+  def self.input_text(label : String, buf : Bytes) : Bool
+    LibImGui.imgui_input_text(label, buf.to_unsafe, buf.size) != 0
+  end
+
+  def self.input_text_multiline(label : String, buf : Bytes, w : Float32 = -1.0f32, h : Float32 = 80.0f32) : Bool
+    LibImGui.imgui_input_text_multiline(label, buf.to_unsafe, buf.size, w, h) != 0
+  end
+
+  def self.checkbox(label : String, checked : Bool) : {Bool, Bool}
+    v = checked ? 1 : 0
+    changed = LibImGui.imgui_checkbox(label, pointerof(v)) != 0
+    {changed, v != 0}
+  end
+
+  def self.slider_float(label : String, value : Float32, min : Float32, max : Float32) : {Bool, Float32}
+    v = value
+    changed = LibImGui.imgui_slider_float(label, pointerof(v), min, max) != 0
+    {changed, v}
+  end
+
+  def self.progress_bar(fraction : Float32, w : Float32 = -1.0f32, h : Float32 = 0.0f32, overlay : String = "")
+    LibImGui.imgui_progress_bar(fraction, w, h, overlay)
+  end
+
+  def self.set_next_window_pos(x : Float32, y : Float32)
+    LibImGui.imgui_set_next_window_pos(x, y)
+  end
+
+  def self.set_next_window_size(w : Float32, h : Float32)
+    LibImGui.imgui_set_next_window_size(w, h)
+  end
+
+  def self.push_font_scale(scale : Float32)
+    LibImGui.imgui_push_font_scale(scale)
+  end
+
+  def self.pop_font_scale
+    LibImGui.imgui_pop_font_scale
+  end
+
+  def self.push_style_color(idx : Int32, r : Float32, g : Float32, b : Float32, a : Float32 = 1.0f32)
+    LibImGui.imgui_push_style_color(idx, r, g, b, a)
+  end
+
+  def self.pop_style_color(count : Int32 = 1)
+    LibImGui.imgui_pop_style_color(count)
+  end
+
+  def self.push_style_var(idx : Int32, val : Float32)
+    LibImGui.imgui_push_style_var_float(idx, val)
+  end
+
+  def self.pop_style_var(count : Int32 = 1)
+    LibImGui.imgui_pop_style_var(count)
+  end
+
+  def self.begin_child(id : String, w : Float32 = 0.0f32, h : Float32 = 0.0f32, border : Bool = false, flags : Int32 = 0) : Bool
+    LibImGui.imgui_begin_child(id, w, h, border ? 1 : 0, flags) != 0
+  end
+
+  def self.end_child
+    LibImGui.imgui_end_child
+  end
+
+  def self.same_line(offset : Float32 = 0.0f32, spacing : Float32 = -1.0f32)
+    LibImGui.imgui_same_line(offset, spacing)
+  end
+
+  def self.get_display_size : {Float32, Float32}
+    w = 0.0f32
+    h = 0.0f32
+    LibImGui.imgui_get_display_size(pointerof(w), pointerof(h))
+    {w, h}
+  end
+
+  def self.font_size : Float32
+    LibImGui.imgui_get_font_size
+  end
+
+  def self.backend_init(window : Void*, gl_ctx : Void*) : Bool
+    LibImGui.imgui_backend_init(window, gl_ctx) != 0
+  end
+
+  def self.backend_shutdown
+    LibImGui.imgui_backend_shutdown
+  end
+
+  def self.backend_new_frame(window : Void*)
+    LibImGui.imgui_backend_new_frame(window)
+  end
+
+  def self.backend_render(draw_data : Void*)
+    LibImGui.imgui_backend_render(draw_data)
+  end
+
+  def self.backend_process_event(event : Void*) : Bool
+    LibImGui.imgui_backend_process_event(event) != 0
+  end
+end

--- a/src/native/interpreter/imgui/lib_sdl.cr
+++ b/src/native/interpreter/imgui/lib_sdl.cr
@@ -1,0 +1,216 @@
+@[Link("SDL2")]
+lib LibSDL
+  SDL_INIT_VIDEO   = 0x00000020_u32
+  SDL_INIT_EVENTS  = 0x00004000_u32
+
+  SDL_WINDOW_OPENGL        = 0x00000002_u32
+  SDL_WINDOW_RESIZABLE     = 0x00000020_u32
+  SDL_WINDOW_SHOWN         = 0x00000004_u32
+  SDL_WINDOW_ALLOW_HIGHDPI = 0x00002000_u32
+
+  SDL_WINDOWPOS_CENTERED = 0x2FFF0000_i32
+
+  SDL_GL_CONTEXT_MAJOR_VERSION = 17
+  SDL_GL_CONTEXT_MINOR_VERSION = 18
+  SDL_GL_CONTEXT_PROFILE_MASK  = 21
+  SDL_GL_CONTEXT_PROFILE_CORE  = 0x0001
+  SDL_GL_DOUBLEBUFFER          = 5
+  SDL_GL_DEPTH_SIZE            = 6
+  SDL_GL_STENCIL_SIZE          = 13
+
+  SDL_QUIT            = 0x100
+  SDL_KEYDOWN         = 0x300
+  SDL_KEYUP           = 0x301
+  SDL_MOUSEMOTION     = 0x400
+  SDL_MOUSEBUTTONDOWN = 0x401
+  SDL_MOUSEBUTTONUP   = 0x402
+  SDL_MOUSEWHEEL      = 0x403
+  SDL_TEXTINPUT       = 0x303
+  SDL_WINDOWEVENT     = 0x200
+
+  SDLK_ESCAPE = 27
+  SDLK_RETURN = 13
+
+  struct KeySym
+    scancode : Int32
+    sym      : Int32
+    mod      : UInt16
+    unused   : UInt32
+  end
+
+  struct KeyboardEvent
+    type      : UInt32
+    timestamp : UInt32
+    window_id : UInt32
+    state     : UInt8
+    repeat    : UInt8
+    padding2  : UInt8
+    padding3  : UInt8
+    keysym    : KeySym
+  end
+
+  struct MouseMotionEvent
+    type      : UInt32
+    timestamp : UInt32
+    window_id : UInt32
+    which     : UInt32
+    state     : UInt32
+    x         : Int32
+    y         : Int32
+    xrel      : Int32
+    yrel      : Int32
+  end
+
+  struct MouseButtonEvent
+    type      : UInt32
+    timestamp : UInt32
+    window_id : UInt32
+    which     : UInt32
+    button    : UInt8
+    state     : UInt8
+    clicks    : UInt8
+    padding1  : UInt8
+    x         : Int32
+    y         : Int32
+  end
+
+  struct MouseWheelEvent
+    type      : UInt32
+    timestamp : UInt32
+    window_id : UInt32
+    which     : UInt32
+    x         : Int32
+    y         : Int32
+    direction : UInt32
+    preciseX  : Float32
+    preciseY  : Float32
+  end
+
+  struct TextInputEvent
+    type      : UInt32
+    timestamp : UInt32
+    window_id : UInt32
+    text      : UInt8[32]
+  end
+
+  struct WindowEvent
+    type      : UInt32
+    timestamp : UInt32
+    window_id : UInt32
+    event     : UInt8
+    padding1  : UInt8
+    padding2  : UInt8
+    padding3  : UInt8
+    data1     : Int32
+    data2     : Int32
+  end
+
+  struct QuitEvent
+    type      : UInt32
+    timestamp : UInt32
+  end
+
+  union Event
+    type     : UInt32
+    key      : KeyboardEvent
+    motion   : MouseMotionEvent
+    button   : MouseButtonEvent
+    wheel    : MouseWheelEvent
+    text     : TextInputEvent
+    window   : WindowEvent
+    quit     : QuitEvent
+    padding  : UInt8[56]
+  end
+
+  fun SDL_Init(flags : UInt32) : Int32
+  fun SDL_Quit()
+  fun SDL_GetError() : UInt8*
+  fun SDL_CreateWindow(title : UInt8*, x : Int32, y : Int32, w : Int32, h : Int32, flags : UInt32) : Void*
+  fun SDL_DestroyWindow(window : Void*)
+  fun SDL_GL_SetAttribute(attr : Int32, value : Int32) : Int32
+  fun SDL_GL_CreateContext(window : Void*) : Void*
+  fun SDL_GL_DeleteContext(context : Void*)
+  fun SDL_GL_SwapWindow(window : Void*)
+  fun SDL_GL_SetSwapInterval(interval : Int32) : Int32
+  fun SDL_PollEvent(event : Event*) : Int32
+  fun SDL_GetWindowSize(window : Void*, w : Int32*, h : Int32*)
+  fun SDL_SetWindowTitle(window : Void*, title : UInt8*)
+  fun SDL_Delay(ms : UInt32)
+end
+
+module SDL
+  def self.init_video
+    LibSDL.SDL_Init(LibSDL::SDL_INIT_VIDEO | LibSDL::SDL_INIT_EVENTS)
+  end
+
+  def self.quit
+    LibSDL.SDL_Quit
+  end
+
+  def self.get_error : String
+    String.new(LibSDL.SDL_GetError)
+  end
+
+  def self.create_window(title : String, w : Int32, h : Int32) : Void*
+    flags = LibSDL::SDL_WINDOW_OPENGL |
+            LibSDL::SDL_WINDOW_RESIZABLE |
+            LibSDL::SDL_WINDOW_SHOWN |
+            LibSDL::SDL_WINDOW_ALLOW_HIGHDPI
+    LibSDL.SDL_CreateWindow(
+      title,
+      LibSDL::SDL_WINDOWPOS_CENTERED,
+      LibSDL::SDL_WINDOWPOS_CENTERED,
+      w, h, flags
+    )
+  end
+
+  def self.destroy_window(window : Void*)
+    LibSDL.SDL_DestroyWindow(window)
+  end
+
+  def self.setup_gl_attributes
+    LibSDL.SDL_GL_SetAttribute(LibSDL::SDL_GL_CONTEXT_PROFILE_MASK, LibSDL::SDL_GL_CONTEXT_PROFILE_CORE)
+    LibSDL.SDL_GL_SetAttribute(LibSDL::SDL_GL_CONTEXT_MAJOR_VERSION, 3)
+    LibSDL.SDL_GL_SetAttribute(LibSDL::SDL_GL_CONTEXT_MINOR_VERSION, 0)
+    LibSDL.SDL_GL_SetAttribute(LibSDL::SDL_GL_DOUBLEBUFFER, 1)
+    LibSDL.SDL_GL_SetAttribute(LibSDL::SDL_GL_DEPTH_SIZE, 24)
+    LibSDL.SDL_GL_SetAttribute(LibSDL::SDL_GL_STENCIL_SIZE, 8)
+  end
+
+  def self.gl_create_context(window : Void*) : Void*
+    LibSDL.SDL_GL_CreateContext(window)
+  end
+
+  def self.gl_delete_context(ctx : Void*)
+    LibSDL.SDL_GL_DeleteContext(ctx)
+  end
+
+  def self.gl_swap_window(window : Void*)
+    LibSDL.SDL_GL_SwapWindow(window)
+  end
+
+  def self.gl_set_swap_interval(interval : Int32)
+    LibSDL.SDL_GL_SetSwapInterval(interval)
+  end
+
+  def self.poll_event : LibSDL::Event?
+    event = LibSDL::Event.new
+    return event if LibSDL.SDL_PollEvent(pointerof(event)) != 0
+    nil
+  end
+
+  def self.get_window_size(window : Void*) : {Int32, Int32}
+    w = 0
+    h = 0
+    LibSDL.SDL_GetWindowSize(window, pointerof(w), pointerof(h))
+    {w, h}
+  end
+
+  def self.set_window_title(window : Void*, title : String)
+    LibSDL.SDL_SetWindowTitle(window, title)
+  end
+
+  def self.delay(ms : UInt32)
+    LibSDL.SDL_Delay(ms)
+  end
+end

--- a/src/native/interpreter/interpreter.cr
+++ b/src/native/interpreter/interpreter.cr
@@ -1,0 +1,75 @@
+require "file_utils"
+require "./nodes"
+require "./parser"
+require "./renderer"
+
+module Native::Interpreter
+  class Interpreter
+    WATCH_INTERVAL = 0.15.seconds
+
+    @source_file : String
+    @renderer : Renderer
+    @last_mtime : Time = Time::UNIX_EPOCH
+
+    def initialize(@source_file : String)
+      @renderer = Renderer.new
+    end
+
+    def run
+      unless File.exists?(@source_file)
+        STDERR.puts "[native.cr] Interpreter: file not found: #{@source_file}"
+        exit(1)
+      end
+
+      puts "[native.cr] Interpreter starting"
+      puts "[native.cr] Watching: #{@source_file}"
+      puts "[native.cr] Press Escape or close the window to quit"
+      puts ""
+
+      app = parse_file
+      @renderer.update_app(app)
+
+      watcher_fiber = spawn do
+        loop do
+          begin
+            current_mtime = File.info(@source_file).modification_time
+            if current_mtime != @last_mtime
+              @last_mtime = current_mtime
+              puts "[native.cr] Reloading: #{@source_file}"
+              reloaded = parse_file
+              @renderer.update_app(reloaded)
+            end
+          rescue e
+            puts "[native.cr] Watch error: #{e.message}"
+          end
+          sleep WATCH_INTERVAL
+        end
+      end
+
+      _ = watcher_fiber
+
+      @renderer.run
+    end
+
+    private def parse_file : AppNode
+      source = File.read(@source_file)
+      parser = Parser.new(source)
+      app = parser.parse
+      if err = app.error_message
+        puts "[native.cr] Parse error: #{err}"
+      else
+        puts "[native.cr] Parsed #{@source_file}: #{count_nodes(app.root)} nodes"
+      end
+      app
+    rescue e
+      app = AppNode.new
+      app.error_message = "Read error: #{e.message}"
+      app
+    end
+
+    private def count_nodes(node : UINode?) : Int32
+      return 0 unless node
+      1 + node.children.sum { |c| count_nodes(c) }
+    end
+  end
+end

--- a/src/native/interpreter/nodes.cr
+++ b/src/native/interpreter/nodes.cr
@@ -1,0 +1,134 @@
+module Native::Interpreter
+  enum Orientation
+    Vertical
+    Horizontal
+  end
+
+  abstract class UINode
+    property id : String
+    property visible : Bool = true
+    property children : Array(UINode) = [] of UINode
+
+    def initialize(@id : String)
+    end
+
+    def add_child(node : UINode)
+      @children << node
+    end
+  end
+
+  class TextViewNode < UINode
+    property text : String
+    property text_size : Int32 = 14
+    property bold : Bool = false
+    property color : Tuple(Float32, Float32, Float32) = {1.0f32, 1.0f32, 1.0f32}
+
+    def initialize(id : String, @text : String)
+      super(id)
+    end
+  end
+
+  class ButtonNode < UINode
+    property label : String
+    property on_click_body : String = ""
+    property enabled : Bool = true
+
+    def initialize(id : String, @label : String)
+      super(id)
+    end
+  end
+
+  class EditTextNode < UINode
+    property placeholder : String
+    property value : String = ""
+    property multiline : Bool = false
+
+    def initialize(id : String, @placeholder : String)
+      super(id)
+    end
+  end
+
+  class CheckboxNode < UINode
+    property label : String
+    property checked : Bool = false
+
+    def initialize(id : String, @label : String)
+      super(id)
+    end
+  end
+
+  class SliderNode < UINode
+    property label : String
+    property value : Float32 = 0.0f32
+    property min : Float32 = 0.0f32
+    property max : Float32 = 1.0f32
+
+    def initialize(id : String, @label : String, @min : Float32, @max : Float32)
+      super(id)
+    end
+  end
+
+  class LinearLayoutNode < UINode
+    property orientation : Orientation
+
+    def initialize(id : String, @orientation : Orientation = Orientation::Vertical)
+      super(id)
+    end
+  end
+
+  class CardViewNode < UINode
+    property title : String = ""
+
+    def initialize(id : String)
+      super(id)
+    end
+  end
+
+  class SeparatorNode < UINode
+    def initialize(id : String)
+      super(id)
+    end
+  end
+
+  class SpacerNode < UINode
+    property height : Int32 = 8
+
+    def initialize(id : String, @height : Int32 = 8)
+      super(id)
+    end
+  end
+
+  class ImageViewNode < UINode
+    property src : String = ""
+
+    def initialize(id : String, @src : String = "")
+      super(id)
+    end
+  end
+
+  class ProgressBarNode < UINode
+    property value : Float32 = 0.0f32
+    property label : String = ""
+
+    def initialize(id : String)
+      super(id)
+    end
+  end
+
+  class ScrollViewNode < UINode
+    def initialize(id : String)
+      super(id)
+    end
+  end
+
+  class AppNode
+    property class_name : String = "App"
+    property title : String = "native.cr Preview"
+    property root : UINode?
+    property state_vars : Hash(String, String) = {} of String => String
+    property error_message : String? = nil
+
+    def initialize(@class_name : String = "App")
+    end
+  end
+end

--- a/src/native/interpreter/parser.cr
+++ b/src/native/interpreter/parser.cr
@@ -1,0 +1,257 @@
+module Native::Interpreter
+  class Parser
+    @source : String
+    @lines : Array(String)
+    @counter : Int32 = 0
+
+    def initialize(@source : String)
+      @lines = @source.split('\n')
+    end
+
+    def parse : AppNode
+      app = AppNode.new
+      app.error_message = nil
+
+      begin
+        class_name = extract_class_name
+        app.class_name = class_name if class_name
+        app.title = "#{class_name || "App"} — native.cr Preview"
+
+        setup_body = extract_setup_body
+        if setup_body.nil?
+          app.error_message = "No 'def setup' method found"
+          return app
+        end
+
+        vars = build_variable_table(setup_body)
+        root = build_tree(setup_body, vars)
+        app.root = root
+        app.state_vars = extract_preserve_vars(@source)
+      rescue e
+        app.error_message = "Parse error: #{e.message}"
+      end
+
+      app
+    end
+
+    private def next_id(prefix : String = "node") : String
+      @counter += 1
+      "#{prefix}_#{@counter}"
+    end
+
+    private def extract_class_name : String?
+      @lines.each do |line|
+        if m = line.match(/class\s+(\w+)\s*<\s*(?:Native::)?App/)
+          return m[1]
+        end
+      end
+      nil
+    end
+
+    private def extract_setup_body : String?
+      in_setup = false
+      found_setup = false
+      depth = 0
+      body_lines = [] of String
+
+      @lines.each do |line|
+        stripped = line.strip
+
+        if !in_setup && stripped =~ /def\s+setup\b/
+          in_setup = true
+          found_setup = true
+          depth = 1
+          next
+        end
+
+        if in_setup
+          depth += stripped.scan(/\b(do|begin|if|unless|case|while|until|for|def|class|module|loop)\b/).size
+          depth += stripped.scan(/\bdo\s*(\|[^|]*\|)?\s*$/).size
+          depth += (stripped == "{" ? 1 : 0)
+          depth -= stripped.scan(/\bend\b/).size
+          depth -= (stripped == "}" ? 1 : 0)
+
+          break if depth <= 0
+
+          body_lines << line
+        end
+      end
+
+      return nil unless found_setup
+      body_lines.join('\n')
+    end
+
+    private def build_variable_table(body : String) : Hash(String, UINode)
+      vars = {} of String => UINode
+      body.split('\n').each do |line|
+        stripped = line.strip
+        next if stripped.starts_with?('#')
+
+        if m = stripped.match(/^(\w+)\s*=\s*(.+)$/)
+          var_name = m[1]
+          rhs = m[2].strip
+          node = parse_widget(rhs)
+          vars[var_name] = node if node
+        end
+      end
+      vars
+    end
+
+    private def build_tree(body : String, vars : Hash(String, UINode)) : UINode
+      lines = body.split('\n').map(&.strip).reject { |l| l.empty? || l.starts_with?('#') }
+
+      add_relationships(lines, vars)
+
+      top_level = find_top_level_nodes(lines, vars)
+
+      if top_level.size == 1
+        return top_level.first
+      end
+
+      root_layout = LinearLayoutNode.new(next_id("root_layout"), Orientation::Vertical)
+
+      if top_level.empty?
+        vars.values.each { |v| root_layout.add_child(v) }
+      else
+        top_level.each { |n| root_layout.add_child(n) }
+      end
+
+      root_layout
+    end
+
+    private def add_relationships(lines : Array(String), vars : Hash(String, UINode))
+      lines.each do |line|
+        if m = line.match(/^(\w+)\.add(?:_child|_view)?\((\w+)(?:,.*?)?\)/)
+          parent_name = m[1]
+          child_name = m[2]
+          parent = vars[parent_name]?
+          child = vars[child_name]?
+          parent.add_child(child) if parent && child
+        end
+
+        apply_property(line, vars)
+      end
+    end
+
+    private def apply_property(line : String, vars : Hash(String, UINode))
+      if m = line.match(/^(\w+)\.text\s*=\s*["'](.+?)["']/)
+        node = vars[m[1]]?
+        if node.is_a?(TextViewNode)
+          node.text = m[2]
+        end
+      end
+
+      if m = line.match(/^(\w+)\.text_size\s*=\s*(\d+)/)
+        node = vars[m[1]]?
+        if node.is_a?(TextViewNode)
+          node.text_size = m[2].to_i
+        end
+      end
+
+      if m = line.match(/^(\w+)\.placeholder\s*=\s*["'](.+?)["']/)
+        node = vars[m[1]]?
+        if node.is_a?(EditTextNode)
+          node.placeholder = m[2]
+        end
+      end
+
+      if m = line.match(/^(\w+)\.checked\s*=\s*(true|false)/)
+        node = vars[m[1]]?
+        if node.is_a?(CheckboxNode)
+          node.checked = m[2] == "true"
+        end
+      end
+
+      if m = line.match(/^(\w+)\.on_click\s*\{(.+?)\}/)
+        node = vars[m[1]]?
+        if node.is_a?(ButtonNode)
+          node.on_click_body = m[2].strip
+        end
+      end
+
+      if m = line.match(/^(\w+)\.value\s*=\s*([\d.]+)/)
+        node = vars[m[1]]?
+        if node.is_a?(SliderNode)
+          node.value = m[2].to_f32
+        elsif node.is_a?(ProgressBarNode)
+          node.value = m[2].to_f32
+        end
+      end
+    end
+
+    private def find_top_level_nodes(lines : Array(String), vars : Hash(String, UINode)) : Array(UINode)
+      children_names = Set(String).new
+
+      lines.each do |line|
+        if m = line.match(/^(\w+)\.add(?:_child|_view)?\((\w+)/)
+          children_names.add(m[2])
+        end
+      end
+
+      top = [] of UINode
+      lines.each do |line|
+        if m = line.match(/^(\w+)\s*=\s*/)
+          var_name = m[1]
+          node = vars[var_name]?
+          top << node if node && !children_names.includes?(var_name)
+        end
+      end
+
+      top
+    end
+
+    private def parse_widget(expr : String) : UINode?
+      case expr
+      when /^(?:Native::UI::)?TextView\.new\(["'](.+?)["']\)/
+        TextViewNode.new(next_id("tv"), $~[1])
+      when /^(?:Native::UI::)?TextView\.new\(\)/
+        TextViewNode.new(next_id("tv"), "")
+      when /^(?:Native::UI::)?Button\.new\(["'](.+?)["']\)/
+        ButtonNode.new(next_id("btn"), $~[1])
+      when /^(?:Native::UI::)?Button\.new\(\)/
+        ButtonNode.new(next_id("btn"), "Button")
+      when /^(?:Native::UI::)?EditText\.new\(["'](.+?)["']\)/
+        EditTextNode.new(next_id("et"), $~[1])
+      when /^(?:Native::UI::)?EditText\.new\(\)/
+        EditTextNode.new(next_id("et"), "Enter text...")
+      when /^(?:Native::UI::)?CheckBox\.new\(["'](.+?)["']\)/
+        CheckboxNode.new(next_id("cb"), $~[1])
+      when /^(?:Native::UI::)?CheckBox\.new\(\)/
+        CheckboxNode.new(next_id("cb"), "Option")
+      when /^(?:Native::UI::)?LinearLayout\.new\(:vertical\)/
+        LinearLayoutNode.new(next_id("layout"), Orientation::Vertical)
+      when /^(?:Native::UI::)?LinearLayout\.new\(:horizontal\)/
+        LinearLayoutNode.new(next_id("layout"), Orientation::Horizontal)
+      when /^(?:Native::UI::)?LinearLayout\.new\(\)/
+        LinearLayoutNode.new(next_id("layout"), Orientation::Vertical)
+      when /^(?:Native::UI::)?CardView\.new\(\)/
+        CardViewNode.new(next_id("card"))
+      when /^(?:Native::UI::)?ScrollView\.new\(\)/
+        ScrollViewNode.new(next_id("scroll"))
+      when /^(?:Native::UI::)?ProgressBar\.new\(\)/
+        ProgressBarNode.new(next_id("pb"))
+      when /^(?:Native::UI::)?SeekBar\.new\((.+?),\s*(.+?),\s*(.+?)\)/
+        min = $~[1].to_f32
+        max = $~[2].to_f32
+        label = $~[3].gsub(/["']/, "")
+        SliderNode.new(next_id("slider"), label, min, max)
+      when /^(?:Native::UI::)?SeekBar\.new\(\)/
+        SliderNode.new(next_id("slider"), "Value", 0.0f32, 1.0f32)
+      when /^(?:Native::UI::)?ImageView\.new\(["']?(.+?)["']?\)/
+        ImageViewNode.new(next_id("img"), $~[1])
+      when /^(?:Native::UI::)?ImageView\.new\(\)/
+        ImageViewNode.new(next_id("img"))
+      else
+        nil
+      end
+    end
+
+    private def extract_preserve_vars(source : String) : Hash(String, String)
+      result = {} of String => String
+      source.scan(/@\[Preserve\]\s*\n\s*@(\w+)\s*[:=]\s*(.+)/) do |m|
+        result[m[1]] = m[2].strip
+      end
+      result
+    end
+  end
+end

--- a/src/native/interpreter/renderer.cr
+++ b/src/native/interpreter/renderer.cr
@@ -1,0 +1,378 @@
+require "./nodes"
+require "./imgui/lib_sdl"
+require "./imgui/lib_gl"
+require "./imgui/lib_imgui"
+
+module Native::Interpreter
+  class Renderer
+    WINDOW_W = 480
+    WINDOW_H = 720
+
+    @window : Void* = Pointer(Void).null
+    @gl_ctx : Void* = Pointer(Void).null
+    @running : Bool = false
+    @app : AppNode = AppNode.new
+    @app_mutex : Mutex = Mutex.new
+    @input_buffers : Hash(String, Bytes) = {} of String => Bytes
+    @checkbox_states : Hash(String, Bool) = {} of String => Bool
+    @slider_states : Hash(String, Float32) = {} of String => Float32
+    @status_msg : String = ""
+    @status_timer : Float64 = 0.0
+
+    def update_app(app : AppNode)
+      @app_mutex.synchronize { @app = app }
+    end
+
+    def stop
+      @running = false
+    end
+
+    def run
+      init_sdl_and_imgui
+      main_loop
+    ensure
+      shutdown
+    end
+
+    private def init_sdl_and_imgui
+      if SDL.init_video != 0
+        raise "SDL_Init failed: #{SDL.get_error}"
+      end
+
+      SDL.setup_gl_attributes
+
+      @window = SDL.create_window("native.cr — Desktop Preview", WINDOW_W, WINDOW_H)
+      if @window.null?
+        raise "SDL_CreateWindow failed: #{SDL.get_error}"
+      end
+
+      @gl_ctx = SDL.gl_create_context(@window)
+      if @gl_ctx.null?
+        raise "SDL_GL_CreateContext failed: #{SDL.get_error}"
+      end
+
+      SDL.gl_set_swap_interval(1)
+
+      ImGui.create_context
+      ImGui.style_dark
+
+      unless ImGui.backend_init(@window, @gl_ctx)
+        raise "ImGui backend init failed"
+      end
+
+      @running = true
+      puts "[native.cr] Desktop window open"
+    end
+
+    private def main_loop
+      while @running
+        process_events
+        render_frame
+        SDL.gl_swap_window(@window)
+      end
+    end
+
+    private def process_events
+      while event = SDL.poll_event
+        raw = pointerof(event).as(Void*)
+        ImGui.backend_process_event(raw)
+
+        case event.type
+        when LibSDL::SDL_QUIT
+          @running = false
+        when LibSDL::SDL_KEYDOWN
+          @running = false if event.key.keysym.sym == LibSDL::SDLK_ESCAPE
+        end
+      end
+    end
+
+    private def render_frame
+      win_w, win_h = SDL.get_window_size(@window)
+      GL.viewport(0, 0, win_w, win_h)
+      GL.clear_color(0.08f32, 0.08f32, 0.10f32, 1.0f32)
+      GL.clear
+
+      ImGui.backend_new_frame(@window)
+      ImGui.new_frame
+
+      app = @app_mutex.synchronize { @app }
+      render_app(app, win_w.to_f32, win_h.to_f32)
+
+      ImGui.render
+      ImGui.backend_render(ImGui.get_draw_data)
+    end
+
+    private def render_app(app : AppNode, win_w : Float32, win_h : Float32)
+      if err = app.error_message
+        render_error_window(err, win_w, win_h)
+        return
+      end
+
+      render_toolbar(app, win_w)
+
+      toolbar_h = 36.0f32
+      ImGui.set_next_window_pos(0.0f32, toolbar_h)
+      ImGui.set_next_window_size(win_w, win_h - toolbar_h)
+
+      flags = ImGui::WINDOW_NO_TITLE_BAR |
+              ImGui::WINDOW_NO_RESIZE |
+              ImGui::WINDOW_NO_MOVE |
+              ImGui::WINDOW_NO_SAVED_SETTINGS
+
+      if ImGui.begin("##main_content", flags)
+        if root = app.root
+          render_node(root)
+        else
+          ImGui.text("No UI defined in setup()")
+        end
+
+        render_status_bar
+      end
+      ImGui.end
+    end
+
+    private def render_toolbar(app : AppNode, win_w : Float32)
+      ImGui.set_next_window_pos(0.0f32, 0.0f32)
+      ImGui.set_next_window_size(win_w, 36.0f32)
+
+      flags = ImGui::WINDOW_NO_TITLE_BAR |
+              ImGui::WINDOW_NO_RESIZE |
+              ImGui::WINDOW_NO_MOVE |
+              ImGui::WINDOW_NO_SAVED_SETTINGS |
+              ImGui::WINDOW_NO_SCROLLBAR
+
+      ImGui.push_style_color(ImGui::COL_WINDOW_BG, 0.12f32, 0.12f32, 0.16f32)
+
+      if ImGui.begin("##toolbar", flags)
+        ImGui.push_font_scale(0.85f32)
+        ImGui.text_colored(0.45f32, 0.75f32, 1.0f32, 1.0f32, "native.cr")
+        ImGui.same_line
+        ImGui.text_colored(0.55f32, 0.55f32, 0.60f32, 1.0f32, "—")
+        ImGui.same_line
+        ImGui.text(app.title)
+        ImGui.same_line(0.0f32, 12.0f32)
+        ImGui.text_colored(0.35f32, 0.80f32, 0.40f32, 1.0f32, "● Live")
+        ImGui.pop_font_scale
+      end
+      ImGui.end
+      ImGui.pop_style_color
+    end
+
+    private def render_error_window(err : String, win_w : Float32, win_h : Float32)
+      ImGui.set_next_window_pos(0.0f32, 0.0f32)
+      ImGui.set_next_window_size(win_w, win_h)
+
+      flags = ImGui::WINDOW_NO_TITLE_BAR |
+              ImGui::WINDOW_NO_RESIZE |
+              ImGui::WINDOW_NO_MOVE |
+              ImGui::WINDOW_NO_SAVED_SETTINGS
+
+      ImGui.push_style_color(ImGui::COL_WINDOW_BG, 0.10f32, 0.05f32, 0.05f32)
+
+      if ImGui.begin("##error", flags)
+        ImGui.push_font_scale(1.1f32)
+        ImGui.text_colored(1.0f32, 0.35f32, 0.35f32, 1.0f32, "⚠ Parse Error")
+        ImGui.pop_font_scale
+        ImGui.separator
+        ImGui.spacing
+        ImGui.text_wrapped(err)
+        ImGui.spacing
+        ImGui.separator
+        ImGui.text_colored(0.55f32, 0.55f32, 0.60f32, 1.0f32, "Fix the error in your source file — preview will update automatically.")
+      end
+      ImGui.end
+      ImGui.pop_style_color
+    end
+
+    private def render_node(node : UINode)
+      return unless node.visible
+
+      case node
+      when LinearLayoutNode
+        render_layout(node)
+      when CardViewNode
+        render_card(node)
+      when ScrollViewNode
+        render_scroll(node)
+      when TextViewNode
+        render_text_view(node)
+      when ButtonNode
+        render_button(node)
+      when EditTextNode
+        render_edit_text(node)
+      when CheckboxNode
+        render_checkbox(node)
+      when SliderNode
+        render_slider(node)
+      when ProgressBarNode
+        render_progress_bar(node)
+      when SeparatorNode
+        ImGui.separator
+      when SpacerNode
+        ImGui.dummy(0.0f32, node.height.to_f32)
+      when ImageViewNode
+        render_image_placeholder(node)
+      end
+    end
+
+    private def render_layout(node : LinearLayoutNode)
+      if node.orientation == Orientation::Horizontal
+        node.children.each_with_index do |child, i|
+          render_node(child)
+          ImGui.same_line if i < node.children.size - 1
+        end
+      else
+        node.children.each { |child| render_node(child) }
+      end
+    end
+
+    private def render_card(node : CardViewNode)
+      ImGui.push_style_color(ImGui::COL_WINDOW_BG, 0.14f32, 0.14f32, 0.18f32)
+      ImGui.push_style_var(ImGui::STYLE_VAR_WINDOW_ROUNDING, 6.0f32)
+
+      child_h = estimate_children_height(node.children)
+      if ImGui.begin_child("##card_#{node.id}", -1.0f32, child_h + 16.0f32, true)
+        node.children.each { |child| render_node(child) }
+      end
+      ImGui.end_child
+
+      ImGui.pop_style_color
+      ImGui.pop_style_var
+      ImGui.spacing
+    end
+
+    private def render_scroll(node : ScrollViewNode)
+      child_h = 200.0f32
+      if ImGui.begin_child("##scroll_#{node.id}", -1.0f32, child_h, false, ImGui::WINDOW_HORIZONTAL_SCROLLBAR)
+        node.children.each { |child| render_node(child) }
+      end
+      ImGui.end_child
+    end
+
+    private def render_text_view(node : TextViewNode)
+      if node.text.empty?
+        ImGui.spacing
+        return
+      end
+
+      scale = node.text_size > 14 ? (node.text_size / 14.0f32) : 1.0f32
+      scale = scale.clamp(0.7f32, 2.5f32)
+
+      if scale != 1.0f32
+        ImGui.push_font_scale(scale)
+      end
+
+      r, g, b = node.color
+      if r != 1.0f32 || g != 1.0f32 || b != 1.0f32
+        ImGui.text_colored(r, g, b, 1.0f32, node.text)
+      else
+        ImGui.text_wrapped(node.text)
+      end
+
+      if scale != 1.0f32
+        ImGui.pop_font_scale
+      end
+
+      ImGui.spacing
+    end
+
+    private def render_button(node : ButtonNode)
+      ImGui.push_style_color(ImGui::COL_BUTTON, 0.20f32, 0.35f32, 0.75f32)
+      ImGui.push_style_color(ImGui::COL_BUTTON_HOVERED, 0.30f32, 0.50f32, 0.95f32)
+      ImGui.push_style_color(ImGui::COL_BUTTON_ACTIVE, 0.15f32, 0.28f32, 0.60f32)
+
+      if ImGui.button(node.label, -1.0f32, 32.0f32)
+        @status_msg = "#{node.label} clicked"
+        @status_timer = Time.monotonic.total_seconds
+      end
+
+      ImGui.pop_style_color(3)
+      ImGui.spacing
+    end
+
+    private def render_edit_text(node : EditTextNode)
+      buf = @input_buffers[node.id] ||= Bytes.new(256, 0_u8)
+
+      ImGui.push_style_color(ImGui::COL_FRAME_BG, 0.16f32, 0.16f32, 0.22f32)
+      ImGui.push_style_color(ImGui::COL_FRAME_BG_HOVERED, 0.20f32, 0.20f32, 0.30f32)
+
+      if node.multiline
+        ImGui.input_text_multiline("##et_#{node.id}", buf, -1.0f32, 80.0f32)
+      else
+        ImGui.input_text("#{node.placeholder}##et_#{node.id}", buf)
+      end
+
+      ImGui.pop_style_color(2)
+      ImGui.spacing
+    end
+
+    private def render_checkbox(node : CheckboxNode)
+      state = @checkbox_states.fetch(node.id, node.checked)
+      _, new_state = ImGui.checkbox(node.label, state)
+      @checkbox_states[node.id] = new_state
+      ImGui.spacing
+    end
+
+    private def render_slider(node : SliderNode)
+      value = @slider_states.fetch(node.id, node.value)
+      _, new_val = ImGui.slider_float(node.label, value, node.min, node.max)
+      @slider_states[node.id] = new_val
+      ImGui.spacing
+    end
+
+    private def render_progress_bar(node : ProgressBarNode)
+      ImGui.progress_bar(node.value, -1.0f32, 0.0f32, "#{(node.value * 100).to_i}%")
+      ImGui.spacing
+    end
+
+    private def render_image_placeholder(node : ImageViewNode)
+      ImGui.push_style_color(ImGui::COL_FRAME_BG, 0.16f32, 0.16f32, 0.22f32)
+      if ImGui.begin_child("##img_#{node.id}", -1.0f32, 80.0f32, true)
+        ImGui.text_colored(0.50f32, 0.50f32, 0.55f32, 1.0f32, "[ImageView: #{node.src.empty? ? "no src" : node.src}]")
+      end
+      ImGui.end_child
+      ImGui.pop_style_color
+      ImGui.spacing
+    end
+
+    private def render_status_bar
+      return if @status_msg.empty?
+
+      elapsed = Time.monotonic.total_seconds - @status_timer
+      if elapsed > 2.0
+        @status_msg = ""
+        return
+      end
+
+      alpha = elapsed > 1.5 ? ((2.0 - elapsed) / 0.5).to_f32 : 1.0f32
+      ImGui.spacing
+      ImGui.separator
+      ImGui.text_colored(0.40f32, 0.85f32, 0.45f32, alpha, @status_msg)
+    end
+
+    private def estimate_children_height(children : Array(UINode)) : Float32
+      h = 0.0f32
+      children.each do |child|
+        h += case child
+             when TextViewNode   then 28.0f32
+             when ButtonNode     then 44.0f32
+             when EditTextNode   then 36.0f32
+             when CheckboxNode   then 28.0f32
+             when SliderNode     then 36.0f32
+             when SeparatorNode  then 12.0f32
+             when SpacerNode     then child.height.to_f32
+             else                    40.0f32
+             end
+      end
+      h.clamp(40.0f32, 400.0f32)
+    end
+
+    private def shutdown
+      ImGui.backend_shutdown
+      ImGui.destroy_context
+      SDL.gl_delete_context(@gl_ctx) unless @gl_ctx.null?
+      SDL.destroy_window(@window)   unless @window.null?
+      SDL.quit
+    end
+  end
+end

--- a/src/native_interpreter_main.cr
+++ b/src/native_interpreter_main.cr
@@ -1,0 +1,4 @@
+require "./native/interpreter/interpreter"
+
+file = ARGV[0]? || "src/main.cr"
+Native::Interpreter::Interpreter.new(file).run


### PR DESCRIPTION
  - src/native/interpreter/: parser, renderer, nodes, ImGui C bindings
  - src/native_interpreter_main.cr: interpreter entry point
  - src/native/cli/reload.cr: routes reload command to interpreter
  - spec/interpreter/: 73 specs for nodes and parser (all passing)
  - vendor/imgui/: Dear ImGui library built on first run

  native.cr reload <file> now uses the interpreter for instant hot reload
  without recompiling Crystal code on every save.


## Description

Please provide a summary of the changes and which issue is fixed.

Fixes #(issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI pipeline change

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have ran `crystal tool format` on my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [ ] I have added an entry to CHANGELOG.md

## Platform Impact

- [ ] Android
- [ ] iOS
- [ ] Both

## Testing Done

Describe the tests you ran to verify your changes.

## Additional Context

Add any other context about the pull request here.
