### PR TITLE
fix(engine): rewrite show.cr — remove draw() dependency, use crsfml

### DIFF
--- a/src/native/engine/show.cr
+++ b/src/native/engine/show.cr
@@ -1,83 +1,91 @@
-require "sdl"
-require "opengl"
+require "crsfml"
 
-class NativeDesktop
-  WIDTH  = 1024
-  HEIGHT =  768
+# Desktop preview runner for native.cr apps.
+# Uses SFML (crsfml shard) for cross-platform windowing and event handling.
+#
+# Usage:
+#   require "native"
+#   require "native/engine/show"
+#
+#   class MyApp < Native::App
+#     def setup
+#       puts "App ready!"
+#     end
+#   end
+#
+#   Native::DesktopRunner.run(MyApp)
+#
+module Native
+  class DesktopRunner
+    WIDTH  = 1024
+    HEIGHT = 768
+    TITLE  = "native.cr preview"
 
-  def initialize(app_class : Native::App.class)
-    SDL.init(SDL::Init::VIDEO)
+    @app : App
 
-    @window = SDL::Window.new(
-      "native.cr",
-      x: SDL::Window::POS_CENTERED,
-      y: SDL::Window::POS_CENTERED,
-      width: WIDTH,
-      height: HEIGHT,
-      flags: SDL::Window::OPENGL
-    )
+    def initialize(app_class : App.class)
+      @window = SF::RenderWindow.new(
+        SF::VideoMode.new(WIDTH, HEIGHT),
+        TITLE,
+        SF::Style::Default
+      )
+      @window.framerate_limit = 60
 
-    @gl_context = @window.gl_create_context
-    @app = app_class.new
+      @app = app_class.new
+      @running = true
+    end
 
-    setup_opengl
-    @app.setup
-  end
+    def self.run(app_class : App.class)
+      runner = new(app_class)
+      runner.start
+    end
 
-  def run
-    running = true
+    def start
+      @app.setup
+      @app.on_resume
 
-    while running
-      while event = SDL::Event.poll
+      while @running
+        handle_events
+        @window.clear(SF::Color.new(30, 30, 30))
+        # Apps render via their own renderer or the framework's UI system.
+        # No draw() callback — App uses setup + event-driven updates.
+        @window.display
+      end
+
+      @app.on_pause
+      @app.on_destroy
+    end
+
+    private def handle_events
+      while event = @window.poll_event
         case event
-        when SDL::Event::Quit
-          running = false
-        when SDL::Event::KeyDown
-          if event.sym == SDL::Key::ESCAPE
-            running = false
+        when SF::Event::Closed
+          @running = false
+        when SF::Event::KeyPressed
+          if event.code == SF::Keyboard::Escape
+            @running = false
           else
-            @app.on_key_pressed(event.sym.to_i) if @app.responds_to?(:on_key_pressed)
+            @app.on_key_pressed(key_to_int(event.code))
           end
-        when SDL::Event::KeyUp
-          @app.on_key_released(event.sym.to_i) if @app.responds_to?(:on_key_released)
-        when SDL::Event::MouseButtonDown
-          @app.on_touch_began(event.x.to_f32, event.y.to_f32) if @app.responds_to?(:on_touch_began)
-        when SDL::Event::MouseButtonUp
-          @app.on_touch_ended(event.x.to_f32, event.y.to_f32) if @app.responds_to?(:on_touch_ended)
-        when SDL::Event::MouseMotion
-          if event.state != 0
-            @app.on_touch_moved(event.x.to_f32, event.y.to_f32) if @app.responds_to?(:on_touch_moved)
+        when SF::Event::KeyReleased
+          @app.on_key_released(key_to_int(event.code))
+        when SF::Event::MouseButtonPressed
+          @app.on_touch_began(event.x.to_f32, event.y.to_f32)
+        when SF::Event::MouseButtonReleased
+          @app.on_touch_ended(event.x.to_f32, event.y.to_f32)
+        when SF::Event::MouseMoved
+          # Only report moved when a button is held (dragging)
+          if SF::Mouse.pressed?(SF::Mouse::Left) ||
+             SF::Mouse.pressed?(SF::Mouse::Right) ||
+             SF::Mouse.pressed?(SF::Mouse::Middle)
+            @app.on_touch_moved(event.x.to_f32, event.y.to_f32)
           end
         end
       end
+    end
 
-      glClear(GL_COLOR_BUFFER_BIT)
-      @app.draw
-      @window.gl_swap
-      SDL.delay(16)
+    private def key_to_int(code : SF::Keyboard::Key) : Int32
+      code.value
     end
   end
-
-  def finalize
-    @gl_context = nil
-    @window = nil
-    SDL.quit
-  end
-
-  private def setup_opengl
-    glClearColor(0.2, 0.3, 0.3, 1.0)
-    glEnable(GL_BLEND)
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-    glViewport(0, 0, WIDTH, HEIGHT)
-    glMatrixMode(GL_PROJECTION)
-    glLoadIdentity
-    glOrtho(0, WIDTH, HEIGHT, 0, -1, 1)
-    glMatrixMode(GL_MODELVIEW)
-    glLoadIdentity
-  end
 end
-
-app_class = MyApp
-window = NativeDesktop.new(app_class)
-window.run
-window.finalize


### PR DESCRIPTION
## Problem

`show.cr` (desktop preview runner) was broken in several ways:

1. **Calls `@app.draw`** — `Native::App` no longer has a `draw` method (removed in earlier refactor). Only `setup` + event callbacks remain.
2. **Hardcoded `MyApp` class** — references a non-existent `MyApp` constant, making it unusable for any real project.
3. **SDL + OpenGL combo** — overkill for a preview runner. Requires two heavy dependencies.
4. **No lifecycle hooks** — missing `on_resume` / `on_pause` / `on_destroy` calls.

## Changes

- **Replaced `sdl` + `opengl` with `crsfml`** — SFML is a well-maintained, cross-platform multimedia library with clean Crystal bindings (`oprypin/crsfml`). Handles windowing, events, and 2D graphics in one shard.
- **Removed `@app.draw` call** — the framework now uses an event-driven model. Apps set up in `setup` and respond to callbacks.
- **Added `DesktopRunner.run(App.class)`** — clean entry point, no hardcoded class references.
- **Proper lifecycle** — calls `on_resume` after setup, `on_pause` + `on_destroy` on exit.
- **Full event forwarding** — SFML keyboard/mouse events map to all `App` callbacks.

## Usage

```crystal
require "native"
require "native/engine/show"

class MyApp < Native::App
  def setup
    puts "App ready!"
  end
end

Native::DesktopRunner.run(MyApp)
```

## Shard Dependency

Add to your app's `shard.yml`:

```yaml
dependencies:
  crsfml:
    github: oprypin/crsfml
```

## Platform Impact

- [ ] Android
- [ ] iOS
- [x] Desktop preview only

## Checklist

- [x] Follows code style
- [x] `crystal tool format` run
- [x] Removes broken draw() dependency
- [x] Uses well-maintained shard (crsfml)
