### PR TITLE
Fix Android arm64 GC_stackbottom runtime linking error

### DIFF
--- a/src/native/cli/build.cr
+++ b/src/native/cli/build.cr
@@ -90,6 +90,145 @@ module Native::CLI
       end
     end
 
+    # Build a minimal GC stub library for Android arm64.
+    # Crystal's compiler driver adds -lgc to the linker command regardless
+    # of -D without_gc. The host Crystal installation's libgc.a is built for
+    # x86_64 and is incompatible with the aarch64-linux-android target.
+    # This stub provides the GC symbols as no-ops so linking succeeds.
+    private def ensure_gc_stub_android(toolchain : String) : String
+      gc_dir = "#{@output}/gc-android-arm64"
+      stub_a = "#{gc_dir}/libgc.a"
+
+      if File.exists?(stub_a)
+        puts "[native.cr] GC stub already built."
+        return gc_dir
+      end
+
+      puts "[native.cr] Building GC stub for Android arm64..."
+      Dir.mkdir_p(gc_dir)
+
+      clang = "#{toolchain}/bin/aarch64-linux-android24-clang"
+      llvm_ar = "#{toolchain}/bin/llvm-ar"
+
+      gc_stub_c = "#{gc_dir}/gc_stub.c"
+      File.write(gc_stub_c, <<~C
+        #include <stdlib.h>
+        #include <stddef.h>
+        typedef void (*GC_finalization_proc)(void *, void *);
+        typedef int GC_bool;
+        void GC_init(void) {}
+        void *GC_malloc(size_t size) { return malloc(size); }
+        void *GC_malloc_atomic(size_t size) { return malloc(size); }
+        void *GC_malloc_uncollectable(size_t size) { return malloc(size); }
+        void GC_free(void *ptr) { free(ptr); }
+        void *GC_realloc(void *ptr, size_t size) { return realloc(ptr, size); }
+        void GC_gcollect(void) {}
+        void GC_enable(void) {}
+        void GC_disable(void) {}
+        GC_bool GC_is_disabled(void) { return 0; }
+        void *GC_base(void *ptr) { return NULL; }
+        void GC_register_finalizer_no_order(void *obj, GC_finalization_proc fn, void *cd, GC_finalization_proc *ofn, void **ocd) {}
+        int GC_register_disappearing_link(void **link) { return 0; }
+        int GC_unregister_disappearing_link(void **link) { return 0; }
+        size_t GC_get_heap_size(void) { return 0; }
+        size_t GC_get_free_bytes(void) { return 0; }
+        size_t GC_get_unmapped_bytes(void) { return 0; }
+        size_t GC_get_bytes_since_gc(void) { return 0; }
+        size_t GC_get_total_bytes(void) { return 0; }
+        void GC_set_max_heap_size(size_t n) {}
+        int GC_invoke_finalizers(void) { return 0; }
+        void GC_atfork_prepare(void) {}
+        void GC_atfork_parent(void) {}
+        void GC_atfork_child(void) {}
+        C
+      )
+
+      stub_o = "#{gc_dir}/gc_stub.o"
+      `#{clang} -c #{gc_stub_c} -o #{stub_o}`
+      `#{llvm_ar} rcs #{stub_a} #{stub_o}`
+
+      unless File.exists?(stub_a)
+        puts "[native.cr] Error: Failed to build GC stub."
+        exit(1)
+      end
+
+      puts "[native.cr] GC stub built."
+      gc_dir
+    end
+
+    # Build PCRE2 for Android arm64 from source.
+    # Crystal's stdlib requires libpcre2-8 at link time. When targeting
+    # aarch64-linux-android the NDK linker cannot use the host x86_64 PCRE2.
+    private def ensure_pcre2_android(toolchain : String) : String
+      pcre2_dir = "/tmp/pcre2-android"
+      pcre2_lib = "#{pcre2_dir}/lib/libpcre2-8.a"
+
+      if File.exists?(pcre2_lib)
+        puts "[native.cr] PCRE2 for Android already built."
+        return "#{pcre2_dir}/lib"
+      end
+
+      puts "[native.cr] Building PCRE2 for Android arm64..."
+
+      pcre2_version = "10.42"
+      pcre2_tar = "#{@output}/pcre2-#{pcre2_version}.tar.gz"
+      pcre2_src = "#{@output}/pcre2-#{pcre2_version}"
+
+      unless File.exists?(pcre2_tar)
+        url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-#{pcre2_version}/pcre2-#{pcre2_version}.tar.gz"
+        puts "[native.cr] Downloading PCRE2 #{pcre2_version}..."
+        system("wget -q -O #{pcre2_tar} #{url}")
+        unless File.exists?(pcre2_tar) && File.size(pcre2_tar) > 0
+          puts "[native.cr] Error: Failed to download PCRE2."
+          exit(1)
+        end
+      end
+
+      unless Dir.exists?(pcre2_src)
+        system("tar xzf #{pcre2_tar} -C #{@output}")
+      end
+
+      clang = "#{toolchain}/bin/aarch64-linux-android24-clang"
+      clangxx = "#{toolchain}/bin/aarch64-linux-android24-clang++"
+      llvm_ar = "#{toolchain}/bin/llvm-ar"
+      llvm_ranlib = "#{toolchain}/bin/llvm-ranlib"
+
+      configure_cmd = <<~CMD
+        cd #{pcre2_src} && \
+        ./configure \
+          --host=aarch64-linux-android \
+          --prefix=#{pcre2_dir} \
+          --enable-static \
+          --disable-shared \
+          --disable-jit \
+          CC="#{clang}" \
+          CXX="#{clangxx}" \
+          AR="#{llvm_ar}" \
+          RANLIB="#{llvm_ranlib}" \
+          > #{@output}/pcre2-configure.log 2>&1
+      CMD
+
+      puts "[native.cr] Configuring PCRE2..."
+      system(configure_cmd)
+
+      puts "[native.cr] Compiling PCRE2..."
+      make_cmd = "cd #{pcre2_src} && make -j$(nproc) > #{@output}/pcre2-build.log 2>&1"
+      system(make_cmd)
+
+      puts "[native.cr] Installing PCRE2..."
+      install_cmd = "cd #{pcre2_src} && make install > #{@output}/pcre2-install.log 2>&1"
+      system(install_cmd)
+
+      unless File.exists?(pcre2_lib)
+        puts "[native.cr] Error: Failed to build PCRE2 for Android."
+        puts "[native.cr] Check #{@output}/pcre2-*.log for details."
+        exit(1)
+      end
+
+      puts "[native.cr] PCRE2 built for Android arm64."
+      "#{pcre2_dir}/lib"
+    end
+
     private def build_android
       puts "[native.cr] Building for Android"
       puts "[native.cr] Entry point: #{@entry_point}"
@@ -143,9 +282,18 @@ module Native::CLI
       lib_dir_out = "#{@output}/lib/arm64-v8a"
       Dir.mkdir_p(lib_dir_out)
 
+      # Build GC stub and PCRE2 for Android arm64 cross-compilation.
+      # Crystal's compiler driver adds -lgc regardless of -D without_gc,
+      # so we need an aarch64-compatible libgc.a stub. PCRE2 is also
+      # required by Crystal's stdlib regex support.
+      gc_lib_dir = ensure_gc_stub_android(toolchain)
+      pcre2_lib_dir = ensure_pcre2_android(toolchain)
+
       puts "[native.cr] Compiling user code with framework..."
       user_o = "#{@output}/user_code.o"
-      cmd = "crystal build #{@entry_point} -Dnative_android --target aarch64-linux-android --cross-compile -o #{user_o}"
+      # -Dwithout_gc: use gc/null.cr instead of gc/boehm.cr to avoid
+      # Boehm GC compatibility issues with Android's bionic libc.
+      cmd = "crystal build #{@entry_point} -Dnative_android -Dwithout_gc --target aarch64-linux-android --cross-compile -o #{user_o}"
       cmd += " --release" if @release
       output = `#{cmd} 2>&1`
 
@@ -157,7 +305,7 @@ module Native::CLI
 
       puts "[native.cr] Linking final library..."
       final_so = "#{@output}/lib/arm64-v8a/libnative_app.so"
-      link_cmd = "#{clang} -shared -fPIC -Wl,-soname,libnative_app.so -o #{final_so} #{user_o} #{lib_dir}/native_engine.o -landroid -llog"
+      link_cmd = "#{clang} -shared -fPIC -Wl,-soname,libnative_app.so -o #{final_so} #{user_o} #{lib_dir}/native_engine.o -L#{gc_lib_dir} -L#{pcre2_lib_dir} -lgc -lpcre2-8 -landroid -llog"
       link_output = `#{link_cmd} 2>&1`
 
       unless $?.success?


### PR DESCRIPTION
## Problem

Building an Android app with `native.cr` and running it on an arm64 device crashes at startup with:

```
java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "GC_stackbottom"
    referenced by ".../lib/arm64-v8a/libnative_app.so"
```

## Root Cause

1. **Crystal's compiler driver adds `-lgc` to the linker command regardless of flags.** The host Crystal installation ships an x86_64 `libgc.a` (Boehm GC), which is incompatible with the `aarch64-linux-android` target.

2. **Boehm GC has known compatibility issues with Android's bionic libc**, making it unsuitable for Android shared library builds even when correctly cross-compiled.

3. **PCRE2 is also required** by Crystal's stdlib regex support, but the host's x86_64 `libpcre2-8` is equally incompatible with the Android target.

## Fix

This PR integrates three changes into the CLI `build android` command (`src/native/cli/build.cr`):

1. **GC Stub for arm64** — A new `ensure_gc_stub_android()` method compiles a minimal no-op `libgc.a` for `aarch64-linux-android` using the NDK toolchain. The stub satisfies the `-lgc` flag that Crystal's compiler driver always emits, providing empty implementations for all GC entry points (`GC_init`, `GC_malloc`, `GC_free`, etc.).

2. **PCRE2 cross-compile** — A new `ensure_pcre2_android()` method downloads and builds PCRE2 10.42 from source using the NDK cross-compiler, producing an `aarch64` static library.

3. **Disable Boehm GC at compile time** — The Crystal build command now includes `-Dwithout_gc`, which switches Crystal's stdlib from `gc/boehm.cr` to `gc/null.cr`, avoiding runtime reliance on Boehm GC internals.

4. **Updated link command** — The final `clang` link step now passes `-L<gc_stub_dir> -L<pcre2_lib_dir> -lgc -lpcre2-8` so the NDK linker resolves both libraries against the arm64-compatible versions.

Gradle version is **not modified**.

## Testing

Run `native.cr build android` with `ANDROID_NDK` set. The first build will download/compile PCRE2 and create the GC stub (cached for subsequent builds). The resulting APK should load `libnative_app.so` without the `GC_stackbottom` crash.