### PR TITLE
Fix Android arm64 runtime crash: SIGSEGV in Thread::LinkedList + GC stub calloc

### DIFF
--- a/src/native/cli/build.cr
+++ b/src/native/cli/build.cr
@@ -95,6 +95,11 @@ module Native::CLI
     # of -D without_gc. The host Crystal installation's libgc.a is built for
     # x86_64 and is incompatible with the aarch64-linux-android target.
     # This stub provides the GC symbols as no-ops so linking succeeds.
+    #
+    # CRITICAL: Boehm GC zeroes allocated memory, which Crystal relies on
+    # for object initialization. The stub MUST use calloc (not malloc) to
+    # match this behaviour, otherwise unset pointers contain garbage and
+    # the runtime crashes with SIGSEGV.
     private def ensure_gc_stub_android(toolchain : String) : String
       gc_dir = "#{@output}/gc-android-arm64"
       stub_a = "#{gc_dir}/libgc.a"
@@ -114,14 +119,25 @@ module Native::CLI
       File.write(gc_stub_c, <<~C
         #include <stdlib.h>
         #include <stddef.h>
+        #include <string.h>
         typedef void (*GC_finalization_proc)(void *, void *);
         typedef int GC_bool;
+
+        static void *gc_alloc(size_t size) {
+            void *p = calloc(1, size);
+            return p;
+        }
+
         void GC_init(void) {}
-        void *GC_malloc(size_t size) { return malloc(size); }
-        void *GC_malloc_atomic(size_t size) { return malloc(size); }
-        void *GC_malloc_uncollectable(size_t size) { return malloc(size); }
+        void *GC_malloc(size_t size) { return gc_alloc(size); }
+        void *GC_malloc_atomic(size_t size) { return gc_alloc(size); }
+        void *GC_malloc_uncollectable(size_t size) { return gc_alloc(size); }
         void GC_free(void *ptr) { free(ptr); }
-        void *GC_realloc(void *ptr, size_t size) { return realloc(ptr, size); }
+        void *GC_realloc(void *ptr, size_t size) {
+            void *p = realloc(ptr, size);
+            if (p && ptr != p) memset(p, 0, size);
+            return p;
+        }
         void GC_gcollect(void) {}
         void GC_enable(void) {}
         void GC_disable(void) {}

--- a/src/native/cli/build.cr
+++ b/src/native/cli/build.cr
@@ -90,6 +90,145 @@ module Native::CLI
       end
     end
 
+    # Build a minimal GC stub library for Android arm64.
+    # Crystal's compiler driver adds -lgc to the linker command regardless
+    # of -D without_gc. The host Crystal installation's libgc.a is built for
+    # x86_64 and is incompatible with the aarch64-linux-android target.
+    # This stub provides the GC symbols as no-ops so linking succeeds.
+    private def ensure_gc_stub_android(toolchain : String) : String
+      gc_dir = "#{@output}/gc-android-arm64"
+      stub_a = "#{gc_dir}/libgc.a"
+
+      if File.exists?(stub_a)
+        puts "[native.cr] GC stub already built."
+        return gc_dir
+      end
+
+      puts "[native.cr] Building GC stub for Android arm64..."
+      Dir.mkdir_p(gc_dir)
+
+      clang = "#{toolchain}/bin/aarch64-linux-android24-clang"
+      llvm_ar = "#{toolchain}/bin/llvm-ar"
+
+      gc_stub_c = "#{gc_dir}/gc_stub.c"
+      File.write(gc_stub_c, <<~C
+        #include <stdlib.h>
+        #include <stddef.h>
+        typedef void (*GC_finalization_proc)(void *, void *);
+        typedef int GC_bool;
+        void GC_init(void) {}
+        void *GC_malloc(size_t size) { return malloc(size); }
+        void *GC_malloc_atomic(size_t size) { return malloc(size); }
+        void *GC_malloc_uncollectable(size_t size) { return malloc(size); }
+        void GC_free(void *ptr) { free(ptr); }
+        void *GC_realloc(void *ptr, size_t size) { return realloc(ptr, size); }
+        void GC_gcollect(void) {}
+        void GC_enable(void) {}
+        void GC_disable(void) {}
+        GC_bool GC_is_disabled(void) { return 0; }
+        void *GC_base(void *ptr) { return NULL; }
+        void GC_register_finalizer_no_order(void *obj, GC_finalization_proc fn, void *cd, GC_finalization_proc *ofn, void **ocd) {}
+        int GC_register_disappearing_link(void **link) { return 0; }
+        int GC_unregister_disappearing_link(void **link) { return 0; }
+        size_t GC_get_heap_size(void) { return 0; }
+        size_t GC_get_free_bytes(void) { return 0; }
+        size_t GC_get_unmapped_bytes(void) { return 0; }
+        size_t GC_get_bytes_since_gc(void) { return 0; }
+        size_t GC_get_total_bytes(void) { return 0; }
+        void GC_set_max_heap_size(size_t n) {}
+        int GC_invoke_finalizers(void) { return 0; }
+        void GC_atfork_prepare(void) {}
+        void GC_atfork_parent(void) {}
+        void GC_atfork_child(void) {}
+        C
+      )
+
+      stub_o = "#{gc_dir}/gc_stub.o"
+      `#{clang} -c #{gc_stub_c} -o #{stub_o}`
+      `#{llvm_ar} rcs #{stub_a} #{stub_o}`
+
+      unless File.exists?(stub_a)
+        puts "[native.cr] Error: Failed to build GC stub."
+        exit(1)
+      end
+
+      puts "[native.cr] GC stub built."
+      gc_dir
+    end
+
+    # Build PCRE2 for Android arm64 from source.
+    # Crystal's stdlib requires libpcre2-8 at link time. When targeting
+    # aarch64-linux-android the NDK linker cannot use the host x86_64 PCRE2.
+    private def ensure_pcre2_android(toolchain : String) : String
+      pcre2_dir = "/tmp/pcre2-android"
+      pcre2_lib = "#{pcre2_dir}/lib/libpcre2-8.a"
+
+      if File.exists?(pcre2_lib)
+        puts "[native.cr] PCRE2 for Android already built."
+        return "#{pcre2_dir}/lib"
+      end
+
+      puts "[native.cr] Building PCRE2 for Android arm64..."
+
+      pcre2_version = "10.42"
+      pcre2_tar = "#{@output}/pcre2-#{pcre2_version}.tar.gz"
+      pcre2_src = "#{@output}/pcre2-#{pcre2_version}"
+
+      unless File.exists?(pcre2_tar)
+        url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-#{pcre2_version}/pcre2-#{pcre2_version}.tar.gz"
+        puts "[native.cr] Downloading PCRE2 #{pcre2_version}..."
+        system("wget -q -O #{pcre2_tar} #{url}")
+        unless File.exists?(pcre2_tar) && File.size(pcre2_tar) > 0
+          puts "[native.cr] Error: Failed to download PCRE2."
+          exit(1)
+        end
+      end
+
+      unless Dir.exists?(pcre2_src)
+        system("tar xzf #{pcre2_tar} -C #{@output}")
+      end
+
+      clang = "#{toolchain}/bin/aarch64-linux-android24-clang"
+      clangxx = "#{toolchain}/bin/aarch64-linux-android24-clang++"
+      llvm_ar = "#{toolchain}/bin/llvm-ar"
+      llvm_ranlib = "#{toolchain}/bin/llvm-ranlib"
+
+      configure_cmd = <<~CMD
+        cd #{pcre2_src} && \
+        ./configure \
+          --host=aarch64-linux-android \
+          --prefix=#{pcre2_dir} \
+          --enable-static \
+          --disable-shared \
+          --disable-jit \
+          CC="#{clang}" \
+          CXX="#{clangxx}" \
+          AR="#{llvm_ar}" \
+          RANLIB="#{llvm_ranlib}" \
+          > #{@output}/pcre2-configure.log 2>&1
+      CMD
+
+      puts "[native.cr] Configuring PCRE2..."
+      system(configure_cmd)
+
+      puts "[native.cr] Compiling PCRE2..."
+      make_cmd = "cd #{pcre2_src} && make -j$(nproc) > #{@output}/pcre2-build.log 2>&1"
+      system(make_cmd)
+
+      puts "[native.cr] Installing PCRE2..."
+      install_cmd = "cd #{pcre2_src} && make install > #{@output}/pcre2-install.log 2>&1"
+      system(install_cmd)
+
+      unless File.exists?(pcre2_lib)
+        puts "[native.cr] Error: Failed to build PCRE2 for Android."
+        puts "[native.cr] Check #{@output}/pcre2-*.log for details."
+        exit(1)
+      end
+
+      puts "[native.cr] PCRE2 built for Android arm64."
+      "#{pcre2_dir}/lib"
+    end
+
     private def build_android
       puts "[native.cr] Building for Android"
       puts "[native.cr] Entry point: #{@entry_point}"
@@ -143,9 +282,18 @@ module Native::CLI
       lib_dir_out = "#{@output}/lib/arm64-v8a"
       Dir.mkdir_p(lib_dir_out)
 
+      # Build GC stub and PCRE2 for Android arm64 cross-compilation.
+      # Crystal's compiler driver adds -lgc regardless of -D without_gc,
+      # so we need an aarch64-compatible libgc.a stub. PCRE2 is also
+      # required by Crystal's stdlib regex support.
+      gc_lib_dir = ensure_gc_stub_android(toolchain)
+      pcre2_lib_dir = ensure_pcre2_android(toolchain)
+
       puts "[native.cr] Compiling user code with framework..."
       user_o = "#{@output}/user_code.o"
-      cmd = "crystal build #{@entry_point} -Dnative_android --target aarch64-linux-android --cross-compile -o #{user_o}"
+      # -Dwithout_gc: use gc/null.cr instead of gc/boehm.cr to avoid
+      # Boehm GC compatibility issues with Android's bionic libc.
+      cmd = "crystal build #{@entry_point} -Dnative_android -Dwithout_gc --target aarch64-linux-android --cross-compile -o #{user_o}"
       cmd += " --release" if @release
       output = `#{cmd} 2>&1`
 
@@ -157,7 +305,7 @@ module Native::CLI
 
       puts "[native.cr] Linking final library..."
       final_so = "#{@output}/lib/arm64-v8a/libnative_app.so"
-      link_cmd = "#{clang} -shared -fPIC -Wl,-soname,libnative_app.so -o #{final_so} #{user_o} #{lib_dir}/native_engine.o -landroid -llog"
+      link_cmd = "#{clang} -shared -fPIC -Wl,-soname,libnative_app.so -o #{final_so} #{user_o} #{lib_dir}/native_engine.o -L#{gc_lib_dir} -L#{pcre2_lib_dir} -lgc -lpcre2-8 -landroid -llog"
       link_output = `#{link_cmd} 2>&1`
 
       unless $?.success?

--- a/src/native/engine/android/bridge.cr
+++ b/src/native/engine/android/bridge.cr
@@ -10,6 +10,13 @@ lib LibAndroid
   fun get_activity_class : Void*
 end
 
+# Android entry point — called from native.c's crystal_thread pthread.
+#
+# On Android the user's main.cr is not executed as a normal program
+# entry point; instead the framework calls this function directly.
+# Therefore we cannot assume Native::App.current has been set.
+# Use App.start_registered which starts the subclass the user
+# registered via Native::App.registered_subclass = MyApp.
 fun crystal_android_main(env : Void*, activity : Void*, activity_class : Void*) : Void
   GC.init
 
@@ -17,8 +24,16 @@ fun crystal_android_main(env : Void*, activity : Void*, activity_class : Void*) 
   Native::Android::JNI.set_activity(activity)
   Native::Android::JNI.set_activity_class(activity_class)
 
-  app = Native::App.current
-  app.load_saved_state
-  app.setup
-  app.run
+  begin
+    # Start the registered app subclass. On Android the user should
+    # set Native::App.registered_subclass = MyApp in their main.cr
+    # instead of calling Native::App.start directly.
+    Native::App.start_registered
+  rescue ex
+    # Log the error to Android logcat so it's visible in crash logs.
+    # Avoid calling Crystal's stdlib logging which may trigger
+    # Thread::current and crash again on Android's bionic libc.
+    msg = "native.cr fatal: #{ex.class.name}: #{ex.message}"
+    LibAndroid.__android_log_print(6, "native.cr", msg) # ANDROID_LOG_ERROR = 6
+  end
 end

--- a/src/native/framework/app.cr
+++ b/src/native/framework/app.cr
@@ -1,0 +1,115 @@
+# src/native/framework/app.cr
+
+module Native
+  abstract class App
+    @@current : App?
+    @@registered_subclass : App.class?
+
+    def self.current : App
+      @@current.not_nil!
+    end
+
+    def self.current=(app : App)
+      @@current = app
+    end
+
+    # The app subclass registered by the user for Android builds.
+    # Set this in your main.cr instead of calling App.start directly:
+    #
+    #   class MyApp < Native::App
+    #     def setup; end
+    #   end
+    #   Native::App.registered_subclass = MyApp
+    #
+    # On desktop you can continue to call Native::App.start(MyApp) as before.
+    def self.registered_subclass : App.class?
+      @@registered_subclass
+    end
+
+    def self.registered_subclass=(klass : App.class)
+      @@registered_subclass = klass
+    end
+
+    def self.start(app_class : App.class)
+      app = app_class.new
+      @@current = app
+      app.load_saved_state
+      app.setup
+      app.run
+    end
+
+    # Used by the Android bridge (crystal_android_main) to start the
+    # user's app when the entry-point main.cr doesn't run.
+    def self.start_registered : Nil
+      if subclass = @@registered_subclass
+        start(subclass)
+      elsif app = @@current
+        app.load_saved_state
+        app.setup
+        app.run
+      else
+        raise "No app registered. Set Native::App.registered_subclass = MyApp in your entry point."
+      end
+    end
+
+    def initialize
+      @renderer = Pointer(Void).null
+      setup_signal_handlers
+    end
+
+    private def setup_signal_handlers
+      Signal::USR1.trap { save_state }
+      Signal::TERM.trap { save_state; exit(0) }
+    end
+
+    private def save_state
+      state_file = ENV["NATIVE_CR_STATE_FILE"]?
+      return unless state_file
+      File.write(state_file, state_to_json)
+    rescue
+    end
+
+    def load_saved_state
+      state_file = ENV["NATIVE_CR_STATE_FILE"]?
+      return unless state_file && File.exists?(state_file)
+      json = File.read(state_file)
+      state_from_json(json)
+      File.delete(state_file)
+    rescue
+    end
+
+    def state_to_json : String
+      "{}"
+    end
+
+    def state_from_json(json : String) : Nil
+    end
+
+    abstract def setup : Nil
+
+    def run : Nil
+      loop do
+        sleep 0.016.seconds
+      end
+    end
+
+    # Optional callbacks (stub methods)
+    def on_touch_began(x : Float32, y : Float32) : Nil; end
+
+    def on_touch_moved(x : Float32, y : Float32) : Nil; end
+
+    def on_touch_ended(x : Float32, y : Float32) : Nil; end
+
+    def on_key_pressed(key : Int32) : Nil; end
+
+    def on_key_released(key : Int32) : Nil; end
+
+    def on_pause : Nil; end
+
+    def on_resume : Nil; end
+
+    def on_destroy : Nil; end
+
+    property renderer : Void*
+  end
+end


### PR DESCRIPTION
## Problem

After fixing the `GC_stackbottom` linker error (PR #42), the app now crashes at runtime on Android arm64 with:

```
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x18
 Cause: null pointer dereference
    #00 ... (*Thread::LinkedList(Fiber)#push<Fiber>:Nil+8)
    #01 ... (*Thread::current:Thread+316)
    #02 ... (*Crystal::once ... )
    #03 ... (*Crystal::System::Env::get ... )
    ...
    #11 ... (*Native::App::current ... )  ← NilAssertionError
    #12 ... (crystal_android_main+40)
```

## Root Cause Analysis

This is a **chain crash** — three separate bugs amplify each other:

### Bug 1: `Native::App.current` is nil on Android

`crystal_android_main` calls `Native::App.current` which does `@@current.not_nil!`, but `@@current` is never set because the user's `main.cr` entry point (which calls `App.start`) doesn't execute on Android. Instead the framework jumps directly to `crystal_android_main` from a `pthread` created in `native.c`.

### Bug 2: Crystal's `Thread::current` crashes on Android bionic libc

When the `NilAssertionError` from Bug 1 is raised, Crystal's exception handling calls `Crystal::System::Env::get` → `Crystal::once` → `Thread::current`. `Thread::current` tries to push a Fiber to the thread's linked list, but Crystal's thread-local storage isn't properly initialised on Android's bionic libc from a non-Crystal pthread → **SIGSEGV**.

### Bug 3: GC stub uses `malloc` instead of `calloc`

Boehm GC's `GC_malloc` zeroes allocated memory, which Crystal relies on for object initialization (unset pointers must be null). The previous GC stub used plain `malloc` which leaves memory uninitialised, causing random garbage pointer dereferences.

## Fixes

### 1. App-subclass registration (`src/native/framework/app.cr`)

- Adds `App.registered_subclass` / `App.registered_subclass=` so users can declare their app class from `main.cr`
- Adds `App.start_registered` which starts the registered subclass (used by Android bridge)
- Backwards-compatible — desktop builds calling `App.start()` directly still work

### 2. Android bridge fix (`src/native/engine/android/bridge.cr`)

- `crystal_android_main` now calls `App.start_registered` instead of `App.current`
- Wrapped in `begin/rescue` with `__android_log_print` so future errors go to logcat instead of producing an opaque native crash

### 3. GC stub calloc fix (`src/native/cli/build.cr`)

- `GC_malloc`, `GC_malloc_atomic`, and `GC_malloc_uncollectable` now use `calloc(1, size)` instead of `malloc(size)` to match Boehm GC's zeroing behaviour
- `GC_realloc` zeroes new memory when the pointer moves

### 4. PCRE2 cross-compile (carried from PR #42)

- Builds PCRE2 10.42 from source for `aarch64-linux-android` since Crystal's stdlib regex support requires it

## User-facing changes

Your `main.cr` should now register the app class for Android:

```crystal
class MyApp < Native::App
  def setup
    # your app setup
  end
end

# On Android: register the subclass (the framework starts it)
# On desktop: start directly as before
{% if flag?(:native_android) %}
  Native::App.registered_subclass = MyApp
{% else %}
  Native::App.start(MyApp)
{% end %}
```

Gradle version is **not modified**.