### PR TITLE
fix(cli): commands were running twice (create, build, doctor, sign)

### DIFF
--- a/src/native/cli/build.cr
+++ b/src/native/cli/build.cr
@@ -291,9 +291,3 @@ module Native::CLI
     end
   end
 end
-
-if ARGV.size > 0 && ARGV[0] == "build"
-  args = ARGV[1..-1] || [] of String
-  cmd = Native::CLI::BuildCommand.new(args)
-  cmd.run
-end

--- a/src/native/cli/create.cr
+++ b/src/native/cli/create.cr
@@ -218,9 +218,3 @@ module Native::CLI
     end
   end
 end
-
-if ARGV.size > 0 && ARGV[0] == "create"
-  args = ARGV[1..-1] || [] of String
-  cmd = Native::CLI::CreateCommand.new(args)
-  cmd.run
-end

--- a/src/native/cli/doctor.cr
+++ b/src/native/cli/doctor.cr
@@ -96,9 +96,3 @@ module Native::CLI
     end
   end
 end
-
-if ARGV.size > 0 && ARGV[0] == "doctor"
-  args = ARGV[1..-1] || [] of String
-  cmd = Native::CLI::DoctorCommand.new(args)
-  cmd.run
-end

--- a/src/native/cli/sign.cr
+++ b/src/native/cli/sign.cr
@@ -157,10 +157,3 @@ module Native::CLI
     end
   end
 end
-
-# Add to the CLI entry point
-if ARGV.size > 0 && ARGV[0] == "sign"
-  args = ARGV[1..-1] || [] of String
-  cmd = Native::CLI::SignCommand.new(args)
-  cmd.run
-end


### PR DESCRIPTION
## The problem

`native.cr create my_app` generates the whole project twice, `native.cr build` compiles the entry point twice, and `doctor` / `sign` also run their work twice on a single invocation.

## Why

Each of the four command files still had a leftover top-level dispatch block at the bottom, e.g. in `create.cr`:

```crystal
if ARGV.size > 0 && ARGV[0] == "create"
  args = ARGV[1..-1] || [] of String
  cmd = Native::CLI::CreateCommand.new(args)
  cmd.run
end
```

These files are loaded through `require "./native/cli/*"` inside `src/native.cr`, so that block already runs at require time — and then `Native.run` hits its `case args[0]` dispatch and runs the same command a second time. `sign.cr` even still had a `# Add to the CLI entry point` comment above its block, which is what gave it away.

## The fix

Removes the four top-level blocks. `Native.run`'s `case` dispatch stays as the single entry point, so nothing changes for users except that every command now runs exactly once.

Deletions only — no new behavior, no public API changes.
