### PR TITLE
refactor(android): JNI table alignment fix, completed call/field surface, framework migration batch 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,29 @@ jobs:
 
       - name: Run tests
         run: crystal spec
+
+  typecheck:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: desktop, flags: "" }
+          - { name: android, flags: -Dnative_android }
+          - { name: ios, flags: -Dnative_ios }
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: 1.20.0
+
+      # The platform-conditional code ({% if flag?(:native_android) %} etc.)
+      # is never compiled by the test/build jobs — this is the only place
+      # its types are actually checked.
+      - name: Type-check (${{ matrix.name }})
+        run: crystal build --no-codegen -o /dev/null src/native.cr ${{ matrix.flags }}

--- a/src/native/engine/android/jni.cr
+++ b/src/native/engine/android/jni.cr
@@ -17,7 +17,11 @@
     struct JNINativeInterface
       _p0 : Void*[6]                                                          # 0-5
       find_class : (Void*, UInt8*) -> Void*                                   # 6
-      _p1 : Void*[16]                                                         # 7-22
+      _p1 : Void*[8]                                                          # 7-14
+      exception_occurred : (Void*, Void*) -> Void*                            # 15
+      exception_describe : (Void*) -> Void                                    # 16
+      exception_clear : (Void*) -> Void                                       # 17
+      _p1b : Void*[5]                                                         # 18-22
       delete_local_ref : (Void*, Void*) -> Void                               # 23
       _p2 : Void*[6]                                                          # 24-29
       new_object_a : (Void*, Void*, Void*, JValue*) -> Void*                  # 30
@@ -30,9 +34,13 @@
       call_boolean_method_a : (Void*, Void*, Void*, JValue*) -> UInt8         # 39
       _p5 : Void*[11]                                                         # 40-50
       call_int_method_a : (Void*, Void*, Void*, JValue*) -> Int32             # 51
-      _p6 : Void*[5]                                                          # 52-56
+      _p6 : Void*[2]                                                          # 52-53
+      call_long_method_a : (Void*, Void*, Void*, JValue*) -> Int64            # 54
+      _p6b : Void*[2]                                                         # 55-56
       call_float_method_a : (Void*, Void*, Void*, JValue*) -> Float32         # 57
-      _p7 : Void*[5]                                                          # 58-62
+      _p7 : Void*[2]                                                          # 58-59
+      call_double_method_a : (Void*, Void*, Void*, JValue*) -> Float64        # 60
+      _p7b : Void*[2]                                                         # 61-62
       call_void_method_a : (Void*, Void*, Void*, JValue*) -> Void             # 63
       _p8 : Void*[30]                                                         # 64-93
       get_field_id : (Void*, Void*, UInt8*, UInt8*) -> Void*                  # 94
@@ -40,11 +48,15 @@
       get_boolean_field : (Void*, Void*, Void*) -> UInt8                      # 96
       _p9 : Void*[3]                                                          # 97-99
       get_int_field : (Void*, Void*, Void*) -> Int32                          # 100
-      _p10 : Void*[3]                                                         # 101-103
+      get_long_field : (Void*, Void*, Void*) -> Int64                         # 101
+      get_float_field : (Void*, Void*, Void*) -> Float32                      # 102
+      get_double_field : (Void*, Void*, Void*) -> Float64                     # 103
       set_object_field : (Void*, Void*, Void*, Void*) -> Void                 # 104
       _p11 : Void*[4]                                                         # 105-108
       set_int_field : (Void*, Void*, Void*, Int32) -> Void                    # 109
-      _p12 : Void*[3]                                                         # 110-112
+      set_long_field : (Void*, Void*, Void*, Int64) -> Void                   # 110
+      set_float_field : (Void*, Void*, Void*, Float32) -> Void                # 111
+      set_double_field : (Void*, Void*, Void*, Float64) -> Void               # 112
       get_static_method_id : (Void*, Void*, UInt8*, UInt8*) -> Void*          # 113
       _p13 : Void*[2]                                                         # 114-115
       call_static_object_method_a : (Void*, Void*, Void*, JValue*) -> Void*   # 116
@@ -54,7 +66,9 @@
       call_static_int_method_a : (Void*, Void*, Void*, JValue*) -> Int32      # 131
       _p16 : Void*[2]                                                         # 132-133
       call_static_long_method_a : (Void*, Void*, Void*, JValue*) -> Int64     # 134
-      _p17 : Void*[5]                                                         # 135-139
+      _p17 : Void*[2]                                                         # 135-136
+      call_static_float_method_a : (Void*, Void*, Void*, JValue*) -> Float32  # 137
+      _p17b : Void*[2]                                                        # 138-139
       call_static_double_method_a : (Void*, Void*, Void*, JValue*) -> Float64 # 140
       _p18 : Void*[2]                                                         # 141-142
       call_static_void_method_a : (Void*, Void*, Void*, JValue*) -> Void      # 143
@@ -62,22 +76,33 @@
       get_static_object_field : (Void*, Void*, Void*) -> Void*                # 145
       _p19 : Void*[4]                                                         # 146-149
       get_static_int_field : (Void*, Void*, Void*) -> Int32                   # 150
-      _p20 : Void*[16]                                                        # 151-166
+      get_static_long_field : (Void*, Void*, Void*) -> Int64                  # 151
+      get_static_float_field : (Void*, Void*, Void*) -> Float32               # 152
+      get_static_double_field : (Void*, Void*, Void*) -> Float64              # 153
+      _p20 : Void*[13]                                                        # 154-166
       new_string_utf : (Void*, UInt8*) -> Void*                               # 167
       _p21 : Void*                                                            # 168
       get_string_utf_chars : (Void*, Void*, UInt8*) -> UInt8*                 # 169
       release_string_utf_chars : (Void*, Void*, UInt8*) -> Void               # 170
-      _p22 : Void*[4]                                                         # 171-174
-      get_array_length : (Void*, Void*) -> Int32                              # 175
-      new_object_array : (Void*, Int32, Void*, Void*) -> Void*                # 176
-      get_object_array_element : (Void*, Void*, Int32) -> Void*               # 177
-      set_object_array_element : (Void*, Void*, Int32, Void*) -> Void         # 178
-      _p23 : Void*                                                            # 179
-      new_byte_array : (Void*, Int32) -> Void*                                # 180
-      _p24 : Void*[23]                                                        # 181-203
-      get_byte_array_region : (Void*, Void*, Int32, Int32, UInt8*) -> Void    # 204
-      _p25 : Void*[7]                                                         # 205-211
-      set_byte_array_region : (Void*, Void*, Int32, Int32, UInt8*) -> Void    # 212
+      # NOTE: the real JNI function table continues directly at 171 — there
+      # are no entries between ReleaseStringUTFChars (170) and
+      # GetArrayLength (171). The old layout had a phantom Void*[4] gap
+      # here, shifting every array function +4 slots so they bound to the
+      # WRONG JNI functions on device (new_byte_array hit NewIntArray,
+      # get/set_byte_array_region hit float/double region functions).
+      # Indexes below verified against OpenJDK jni.h JNINativeInterface_.
+      get_array_length : (Void*, Void*) -> Int32                              # 171
+      new_object_array : (Void*, Int32, Void*, Void*) -> Void*                # 172
+      get_object_array_element : (Void*, Void*, Int32) -> Void*               # 173
+      set_object_array_element : (Void*, Void*, Int32, Void*) -> Void         # 174
+      _p22 : Void*                                                            # 175 (NewBooleanArray)
+      new_byte_array : (Void*, Int32) -> Void*                                # 176
+      _p24 : Void*[23]                                                        # 177-199
+      get_byte_array_region : (Void*, Void*, Int32, Int32, UInt8*) -> Void    # 200
+      _p25 : Void*[7]                                                         # 201-207
+      set_byte_array_region : (Void*, Void*, Int32, Int32, UInt8*) -> Void    # 208
+      _p26 : Void*[19]                                                        # 209-227
+      exception_check : (Void*, Void*) -> UInt8                               # 228
     end
 
     alias JavaVM = Void*
@@ -265,7 +290,13 @@ module Native::Android::JNI
     end
 
     def self.call_long_method(obj : Void*, method_id : Void*, args : Array(Void*)? = nil) : Int64
-      0i64
+      e = ep; return 0i64 unless e
+      if a = args
+        jv = a.map { |x| jval_l(x) }
+        e.value.call_long_method_a.call(e.as(Void*), obj, method_id, jv.to_unsafe)
+      else
+        e.value.call_long_method_a.call(e.as(Void*), obj, method_id, Pointer(LibJNI::JValue).null)
+      end
     end
 
     def self.call_float_method(obj : Void*, method_id : Void*, args : Array(Void*)? = nil) : Float32
@@ -279,7 +310,13 @@ module Native::Android::JNI
     end
 
     def self.call_double_method(obj : Void*, method_id : Void*, args : Array(Void*)? = nil) : Float64
-      0.0
+      e = ep; return 0.0 unless e
+      if a = args
+        jv = a.map { |x| jval_l(x) }
+        e.value.call_double_method_a.call(e.as(Void*), obj, method_id, jv.to_unsafe)
+      else
+        e.value.call_double_method_a.call(e.as(Void*), obj, method_id, Pointer(LibJNI::JValue).null)
+      end
     end
 
     def self.call_void_method(obj : Void*, method_id : Void*, args : Array(Void*)? = nil) : Nil
@@ -332,6 +369,16 @@ module Native::Android::JNI
       end
     end
 
+    def self.call_static_float_method(class_ref : Void*, method_id : Void*, args : Array(Void*)? = nil) : Float32
+      e = ep; return 0.0f32 unless e
+      if a = args
+        jv = a.map { |x| jval_l(x) }
+        e.value.call_static_float_method_a.call(e.as(Void*), class_ref, method_id, jv.to_unsafe)
+      else
+        e.value.call_static_float_method_a.call(e.as(Void*), class_ref, method_id, Pointer(LibJNI::JValue).null)
+      end
+    end
+
     def self.call_static_double_method(class_ref : Void*, method_id : Void*, args : Array(Void*)? = nil) : Float64
       e = ep; return 0.0 unless e
       if a = args
@@ -367,6 +414,21 @@ module Native::Android::JNI
       e.value.get_int_field.call(e.as(Void*), obj, field_id)
     end
 
+    def self.get_long_field(obj : Void*, field_id : Void*) : Int64
+      e = ep; return 0i64 unless e
+      e.value.get_long_field.call(e.as(Void*), obj, field_id)
+    end
+
+    def self.get_float_field(obj : Void*, field_id : Void*) : Float32
+      e = ep; return 0.0f32 unless e
+      e.value.get_float_field.call(e.as(Void*), obj, field_id)
+    end
+
+    def self.get_double_field(obj : Void*, field_id : Void*) : Float64
+      e = ep; return 0.0 unless e
+      e.value.get_double_field.call(e.as(Void*), obj, field_id)
+    end
+
     def self.get_static_object_field(class_ref : Void*, field_id : Void*) : Void*
       e = ep; return Pointer(Void).null unless e
       e.value.get_static_object_field.call(e.as(Void*), class_ref, field_id).as(Void*)
@@ -377,6 +439,21 @@ module Native::Android::JNI
       e.value.get_static_int_field.call(e.as(Void*), class_ref, field_id)
     end
 
+    def self.get_static_long_field(class_ref : Void*, field_id : Void*) : Int64
+      e = ep; return 0i64 unless e
+      e.value.get_static_long_field.call(e.as(Void*), class_ref, field_id)
+    end
+
+    def self.get_static_float_field(class_ref : Void*, field_id : Void*) : Float32
+      e = ep; return 0.0f32 unless e
+      e.value.get_static_float_field.call(e.as(Void*), class_ref, field_id)
+    end
+
+    def self.get_static_double_field(class_ref : Void*, field_id : Void*) : Float64
+      e = ep; return 0.0 unless e
+      e.value.get_static_double_field.call(e.as(Void*), class_ref, field_id)
+    end
+
     def self.set_object_field(obj : Void*, field_id : Void*, value : Void*) : Nil
       e = ep; return unless e
       e.value.set_object_field.call(e.as(Void*), obj, field_id, value)
@@ -385,6 +462,39 @@ module Native::Android::JNI
     def self.set_int_field(obj : Void*, field_id : Void*, value : Int32) : Nil
       e = ep; return unless e
       e.value.set_int_field.call(e.as(Void*), obj, field_id, value)
+    end
+
+    def self.set_long_field(obj : Void*, field_id : Void*, value : Int64) : Nil
+      e = ep; return unless e
+      e.value.set_long_field.call(e.as(Void*), obj, field_id, value)
+    end
+
+    def self.set_float_field(obj : Void*, field_id : Void*, value : Float32) : Nil
+      e = ep; return unless e
+      e.value.set_float_field.call(e.as(Void*), obj, field_id, value)
+    end
+
+    def self.set_double_field(obj : Void*, field_id : Void*, value : Float64) : Nil
+      e = ep; return unless e
+      e.value.set_double_field.call(e.as(Void*), obj, field_id, value)
+    end
+
+    # Exception handling — a pending JNI exception makes every subsequent
+    # JNI call undefined behaviour (usually a crash). Check after calls
+    # that can throw (most of them) and clear before continuing.
+    def self.exception_check : Bool
+      e = ep; return false unless e
+      e.value.exception_check.call(e.as(Void*)) != 0
+    end
+
+    def self.exception_clear : Nil
+      e = ep; return unless e
+      e.value.exception_clear.call(e.as(Void*))
+    end
+
+    def self.exception_occurred : Void*
+      e = ep; return Pointer(Void).null unless e
+      e.value.exception_occurred.call(e.as(Void*)).as(Void*)
     end
 
     def self.delete_local_ref(obj : Void*) : Nil
@@ -523,6 +633,10 @@ module Native::Android::JNI
       0i64
     end
 
+    def self.call_static_float_method(c : Void*, m : Void*, args : Array(Void*)? = nil) : Float32
+      0.0f32
+    end
+
     def self.call_static_double_method(c : Void*, m : Void*, args : Array(Void*)? = nil) : Float64
       0.0
     end
@@ -541,12 +655,52 @@ module Native::Android::JNI
       0
     end
 
+    def self.get_long_field(o : Void*, f : Void*) : Int64
+      0i64
+    end
+
+    def self.get_float_field(o : Void*, f : Void*) : Float32
+      0.0f32
+    end
+
+    def self.get_double_field(o : Void*, f : Void*) : Float64
+      0.0
+    end
+
     def self.get_static_object_field(c : Void*, f : Void*) : Void*
       Pointer(Void).null
     end
 
     def self.get_static_int_field(c : Void*, f : Void*) : Int32
       0
+    end
+
+    def self.get_static_long_field(c : Void*, f : Void*) : Int64
+      0i64
+    end
+
+    def self.get_static_float_field(c : Void*, f : Void*) : Float32
+      0.0f32
+    end
+
+    def self.get_static_double_field(c : Void*, f : Void*) : Float64
+      0.0
+    end
+
+    def self.set_long_field(o : Void*, f : Void*, v : Int64) : Nil; end
+
+    def self.set_float_field(o : Void*, f : Void*, v : Float32) : Nil; end
+
+    def self.set_double_field(o : Void*, f : Void*, v : Float64) : Nil; end
+
+    def self.exception_check : Bool
+      false
+    end
+
+    def self.exception_clear : Nil; end
+
+    def self.exception_occurred : Void*
+      Pointer(Void).null
     end
 
     def self.set_object_field(o : Void*, f : Void*, v : Void*) : Nil; end

--- a/src/native/engine/android/jni_env.cr
+++ b/src/native/engine/android/jni_env.cr
@@ -179,7 +179,10 @@
     end
 
     def call_long_method(obj : Void* | Int64, mid : Void*, *jargs) : Int64
-      0i64
+      e = ep; return 0i64 unless e
+      jv = jvalues(jargs)
+      e.value.call_long_method_a.call(e.as(Void*), jobj(obj), mid,
+        jv.empty? ? Pointer(LibJNI::JValue).null : jv.to_unsafe)
     end
 
     def call_float_method(obj : Void* | Int64, mid : Void*, *jargs) : Float32
@@ -190,7 +193,10 @@
     end
 
     def call_double_method(obj : Void* | Int64, mid : Void*, *jargs) : Float64
-      0.0
+      e = ep; return 0.0 unless e
+      jv = jvalues(jargs)
+      e.value.call_double_method_a.call(e.as(Void*), jobj(obj), mid,
+        jv.empty? ? Pointer(LibJNI::JValue).null : jv.to_unsafe)
     end
 
     def call_void_method(obj : Void* | Int64, mid : Void*, *jargs) : Nil
@@ -230,11 +236,86 @@
         jv.empty? ? Pointer(LibJNI::JValue).null : jv.to_unsafe)
     end
 
+    def call_static_float_method(clazz : Void*, mid : Void*, *jargs) : Float32
+      e = ep; return 0.0f32 unless e
+      jv = jvalues(jargs)
+      e.value.call_static_float_method_a.call(e.as(Void*), clazz, mid,
+        jv.empty? ? Pointer(LibJNI::JValue).null : jv.to_unsafe)
+    end
+
     def call_static_double_method(clazz : Void*, mid : Void*, *jargs) : Float64
       e = ep; return 0.0 unless e
       jv = jvalues(jargs)
       e.value.call_static_double_method_a.call(e.as(Void*), clazz, mid,
         jv.empty? ? Pointer(LibJNI::JValue).null : jv.to_unsafe)
+    end
+
+    # ── typed field access (long/float/double round out the existing
+    #    object/boolean/int accessors) ───────────────────────────────────────
+
+    def get_long_field(obj : Void* | Int64, fid : Void*) : Int64
+      e = ep; return 0i64 unless e
+      e.value.get_long_field.call(e.as(Void*), jobj(obj), fid)
+    end
+
+    def get_float_field(obj : Void* | Int64, fid : Void*) : Float32
+      e = ep; return 0.0f32 unless e
+      e.value.get_float_field.call(e.as(Void*), jobj(obj), fid)
+    end
+
+    def get_double_field(obj : Void* | Int64, fid : Void*) : Float64
+      e = ep; return 0.0 unless e
+      e.value.get_double_field.call(e.as(Void*), jobj(obj), fid)
+    end
+
+    def get_static_long_field(clazz : Void*, fid : Void*) : Int64
+      e = ep; return 0i64 unless e
+      e.value.get_static_long_field.call(e.as(Void*), clazz, fid)
+    end
+
+    def get_static_float_field(clazz : Void*, fid : Void*) : Float32
+      e = ep; return 0.0f32 unless e
+      e.value.get_static_float_field.call(e.as(Void*), clazz, fid)
+    end
+
+    def get_static_double_field(clazz : Void*, fid : Void*) : Float64
+      e = ep; return 0.0 unless e
+      e.value.get_static_double_field.call(e.as(Void*), clazz, fid)
+    end
+
+    def set_long_field(obj : Void* | Int64, fid : Void*, value : Int64) : Nil
+      e = ep; return unless e
+      e.value.set_long_field.call(e.as(Void*), jobj(obj), fid, value)
+    end
+
+    def set_float_field(obj : Void* | Int64, fid : Void*, value : Float32) : Nil
+      e = ep; return unless e
+      e.value.set_float_field.call(e.as(Void*), jobj(obj), fid, value)
+    end
+
+    def set_double_field(obj : Void* | Int64, fid : Void*, value : Float64) : Nil
+      e = ep; return unless e
+      e.value.set_double_field.call(e.as(Void*), jobj(obj), fid, value)
+    end
+
+    # ── exception handling ───────────────────────────────────────────────────────
+    # A pending exception makes every subsequent JNI call undefined behaviour.
+    # Check after calls that can throw; clear (or inspect via
+    # exception_occurred) before continuing.
+
+    def exception_check : Bool
+      e = ep; return false unless e
+      e.value.exception_check.call(e.as(Void*)) != 0
+    end
+
+    def exception_clear : Nil
+      e = ep; return unless e
+      e.value.exception_clear.call(e.as(Void*))
+    end
+
+    def exception_occurred : Void*
+      e = ep; return Pointer(Void).null unless e
+      e.value.exception_occurred.call(e.as(Void*)).as(Void*)
     end
 
     def call_static_void_method(clazz : Void*, mid : Void*, *jargs) : Nil

--- a/src/native/engine/android/jni_helpers.cr
+++ b/src/native/engine/android/jni_helpers.cr
@@ -76,6 +76,16 @@
       end
     end
 
+    # ── One-shot boolean call on an object ───────────────────────────────────
+    def self.call_boolean(env : JNIEnvWrapper, obj : Int64, method_name : String, sig : String, *args) : Bool
+      with_object_class(env, obj) do |jclass|
+        return false if jclass.null?
+        mid = env.get_method_id(jclass, method_name, sig)
+        return false if mid.null?
+        env.call_boolean_method(obj, mid, *args)
+      end
+    end
+
     # ── One-shot float call on an object ─────────────────────────────────────
     def self.call_float(env : JNIEnvWrapper, obj : Int64, method_name : String, sig : String, *args) : Float32
       with_object_class(env, obj) do |jclass|
@@ -93,6 +103,70 @@
         mid = env.get_method_id(jclass, method_name, sig)
         return Pointer(Void).null if mid.null?
         env.call_object_method(obj, mid, *args)
+      end
+    end
+
+    # ── One-shot long call on an object ──────────────────────────────────────
+    # The JNIEnvWrapper used to hardcode this to 0i64 — any Java API
+    # returning a long (durations, file sizes, timestamps) silently
+    # reported 0.
+    def self.call_long(env : JNIEnvWrapper, obj : Int64, method_name : String, sig : String, *args) : Int64
+      with_object_class(env, obj) do |jclass|
+        return 0i64 if jclass.null?
+        mid = env.get_method_id(jclass, method_name, sig)
+        return 0i64 if mid.null?
+        env.call_long_method(obj, mid, *args)
+      end
+    end
+
+    # ── One-shot double call on an object ────────────────────────────────────
+    def self.call_double(env : JNIEnvWrapper, obj : Int64, method_name : String, sig : String, *args) : Float64
+      with_object_class(env, obj) do |jclass|
+        return 0.0 if jclass.null?
+        mid = env.get_method_id(jclass, method_name, sig)
+        return 0.0 if mid.null?
+        env.call_double_method(obj, mid, *args)
+      end
+    end
+
+    # ── One-shot call returning a String ─────────────────────────────────────
+    # Reads the returned jstring, then deletes the returned local ref —
+    # the ref returned by call_object belongs to us, so we own the cleanup.
+    def self.call_string(env : JNIEnvWrapper, obj : Int64, method_name : String, sig : String, *args) : String
+      jstr = call_object(env, obj, method_name, sig, *args)
+      return "" if jstr.null?
+      result = env.get_string_utf_chars(jstr)
+      env.delete_local_ref(jstr)
+      result
+    end
+
+    # ── One-shot static int call ─────────────────────────────────────────────
+    def self.call_static_int(env : JNIEnvWrapper, class_name : String, method_name : String, sig : String, *args) : Int32
+      with_class(env, class_name) do |jclass|
+        return 0 if jclass.null?
+        mid = env.get_static_method_id(jclass, method_name, sig)
+        return 0 if mid.null?
+        env.call_static_int_method(jclass, mid, *args)
+      end
+    end
+
+    # ── One-shot static boolean call ─────────────────────────────────────────
+    def self.call_static_boolean(env : JNIEnvWrapper, class_name : String, method_name : String, sig : String, *args) : Bool
+      with_class(env, class_name) do |jclass|
+        return false if jclass.null?
+        mid = env.get_static_method_id(jclass, method_name, sig)
+        return false if mid.null?
+        env.call_static_boolean_method(jclass, mid, *args)
+      end
+    end
+
+    # ── One-shot static float call ───────────────────────────────────────────
+    def self.call_static_float(env : JNIEnvWrapper, class_name : String, method_name : String, sig : String, *args) : Float32
+      with_class(env, class_name) do |jclass|
+        return 0.0f32 if jclass.null?
+        mid = env.get_static_method_id(jclass, method_name, sig)
+        return 0.0f32 if mid.null?
+        env.call_static_float_method(jclass, mid, *args)
       end
     end
 

--- a/src/native/framework/ui/checkbox.cr
+++ b/src/native/framework/ui/checkbox.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/checkbox.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class CheckBox < View
@@ -11,18 +12,17 @@ module Native::UI
       @text = text
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return unless activity
 
-        checkbox_class = env.find_class("android/widget/CheckBox")
-        constructor = env.get_method_id(checkbox_class, "<init>", "(Landroid/content/Context;)V")
-        @native = env.new_object(checkbox_class, constructor, activity).to_i64
+          @native = JNIHelpers.new_widget(env, "android/widget/CheckBox", activity)
 
-        if !text.empty?
-          self.text = text
+          if !text.empty?
+            JNIHelpers.set_text(env, @native, text)
+          end
+          setupCheckedListener(env)
         end
-        setupCheckedListener
       {% elsif flag?(:native_ios) %}
         ptr = LibIOS.create_checkbox
         @native = ptr.to_i64
@@ -35,10 +35,10 @@ module Native::UI
     def checked=(value : Bool)
       @checked = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_checked = env.get_method_id(env.get_object_class(@native), "setChecked", "(Z)V")
-        env.call_void_method(@native, set_checked, value)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "setChecked", "(Z)V", value)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.checkbox_set_checked(@native, value)
       {% end %}
@@ -46,10 +46,10 @@ module Native::UI
 
     def checked? : Bool
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return @checked unless env && @native != 0
-        is_checked = env.get_method_id(env.get_object_class(@native), "isChecked", "()Z")
-        @checked = env.call_boolean_method(@native, is_checked)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          @checked = JNIHelpers.call_boolean(env, @native, "isChecked", "()Z")
+        end
       {% elsif flag?(:native_ios) %}
         @checked = LibIOS.checkbox_is_checked(@native)
       {% end %}
@@ -63,11 +63,10 @@ module Native::UI
     def text=(value : String)
       @text = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        jtext = env.new_string_utf(value)
-        set_text = env.get_method_id(env.get_object_class(@native), "setText", "(Ljava/lang/CharSequence;)V")
-        env.call_void_method(@native, set_text, jtext)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.set_text(env, @native, value)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.checkbox_set_text(@native, value.to_utf8)
       {% end %}
@@ -79,11 +78,10 @@ module Native::UI
 
     def text_color=(value : Native::Math::Color)
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        color = ((value.a * 255).to_i << 24) | ((value.r * 255).to_i << 16) | ((value.g * 255).to_i << 8) | (value.b * 255).to_i
-        set_color = env.get_method_id(env.get_object_class(@native), "setTextColor", "(I)V")
-        env.call_void_method(@native, set_color, color)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.set_text_color(env, @native, argb_from_color(value))
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.checkbox_set_text_color(@native, value.r, value.g, value.b)
       {% end %}
@@ -91,10 +89,10 @@ module Native::UI
 
     def text_size=(value : Int32)
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_size = env.get_method_id(env.get_object_class(@native), "setTextSize", "(F)V")
-        env.call_void_method(@native, set_size, value.to_f32)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.set_text_size(env, @native, value)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.checkbox_set_text_size(@native, value)
       {% end %}
@@ -102,29 +100,42 @@ module Native::UI
 
     def on_checked_change(&block : Bool -> Nil)
       @on_checked_change = block
+      {% if flag?(:native_android) %}
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          setupCheckedListener(env)
+        end
+      {% end %}
     end
 
-    private def setupCheckedListener
+    private def setupCheckedListener(env : Native::Android::JNIEnvWrapper)
       {% unless flag?(:native_android) %}
         return
       {% end %}
-      env = Native::Android::JNI.env
-      return unless env && @native != 0
 
-      callback_class = env.find_class("com/nativecr/CompoundButtonCallback")
-      if callback_class == Pointer(Void).null
-        return
+      callback = JNIHelpers.new_callback(env, "com/nativecr/CompoundButtonCallback", 0i64)
+      return if callback.null?
+
+      begin
+        JNIHelpers.call_void(
+          env, @native, "setOnCheckedChangeListener",
+          "(Landroid/widget/CompoundButton$OnCheckedChangeListener;)V", callback
+        )
+      ensure
+        env.delete_local_ref(callback)
       end
-
-      callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
-
-      set_listener = env.get_method_id(env.get_object_class(@native), "setOnCheckedChangeListener", "(Landroid/widget/CompoundButton$OnCheckedChangeListener;)V")
-      env.call_void_method(@native, set_listener, callback_obj)
     end
 
     def handleCheckedChanged(checked : Bool)
       @checked = checked
       @on_checked_change.try &.call(checked)
+    end
+
+    private def argb_from_color(color : Native::Math::Color) : Int32
+      ((color.a * 255).to_i << 24) |
+      ((color.r * 255).to_i << 16) |
+      ((color.g * 255).to_i << 8) |
+      (color.b * 255).to_i
     end
   end
 end

--- a/src/native/framework/ui/linear_layout.cr
+++ b/src/native/framework/ui/linear_layout.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/linear_layout.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class LinearLayout < View
@@ -33,15 +34,14 @@ module Native::UI
       @orientation = orientation
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return unless activity
 
-        layout_class = env.find_class("android/widget/LinearLayout")
-        constructor = env.get_method_id(layout_class, "<init>", "(Landroid/content/Context;)V")
-        @native = env.new_object(layout_class, constructor, activity).to_i64
+          @native = JNIHelpers.new_widget(env, "android/widget/LinearLayout", activity)
 
-        set_orientation
+          set_orientation(env)
+        end
       {% elsif flag?(:native_ios) %}
         ptr = LibIOS.create_stack_view
         @native = ptr.to_i64
@@ -51,7 +51,10 @@ module Native::UI
     def orientation=(value : Orientation)
       @orientation = value
       {% if flag?(:native_android) %}
-        set_orientation
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          set_orientation(env)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.stack_view_set_axis(@native, value == Orientation::Vertical ? 0 : 1)
       {% end %}
@@ -64,10 +67,10 @@ module Native::UI
     def gravity=(value : Gravity)
       @gravity = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_gravity = env.get_method_id(env.get_object_class(@native), "setGravity", "(I)V")
-        env.call_void_method(@native, set_gravity, value.value)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "setGravity", "(I)V", value.value)
+        end
       {% end %}
     end
 
@@ -78,10 +81,10 @@ module Native::UI
     def weight_sum=(value : Float32)
       @weight_sum = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_weight_sum = env.get_method_id(env.get_object_class(@native), "setWeightSum", "(F)V")
-        env.call_void_method(@native, set_weight_sum, value)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "setWeightSum", "(F)V", value)
+        end
       {% end %}
     end
 
@@ -96,10 +99,10 @@ module Native::UI
       @padding_bottom = bottom
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_padding = env.get_method_id(env.get_object_class(@native), "setPadding", "(IIII)V")
-        env.call_void_method(@native, set_padding, left, top, right, bottom)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "setPadding", "(IIII)V", left, top, right, bottom)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.stack_view_set_padding(@native, left, top, right, bottom)
       {% end %}
@@ -107,21 +110,38 @@ module Native::UI
 
     def addView(view : View, weight : Float32 = 0.0)
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0 && view.native_ptr != 0
+        JNIHelpers.with_env do |env|
+          return if @native == 0 || view.native_ptr == 0
 
-        add_view = env.get_method_id(env.get_object_class(@native), "addView", "(Landroid/view/View;)V")
-        env.call_void_method(@native, add_view, view.native_ptr)
+          JNIHelpers.call_void(env, @native, "addView", "(Landroid/view/View;)V", view.native_ptr)
 
-        if weight > 0
-          layout_params = env.call_object_method(view.native_ptr, env.get_method_id(env.get_object_class(view.native_ptr), "getLayoutParams", "()Landroid/view/ViewGroup$LayoutParams;"))
-          if layout_params
-            linear_params_class = env.find_class("android/widget/LinearLayout$LayoutParams")
-            if env.is_instance_of(layout_params, linear_params_class)
-              set_weight = env.get_method_id(linear_params_class, "setWeight", "(F)V")
-              env.call_void_method(layout_params, set_weight, weight)
-              set_layout = env.get_method_id(env.get_object_class(view.native_ptr), "setLayoutParams", "(Landroid/view/ViewGroup$LayoutParams;)V")
-              env.call_void_method(view.native_ptr, set_layout, layout_params)
+          if weight > 0
+            params = JNIHelpers.call_object(
+              env, view.native_ptr, "getLayoutParams",
+              "()Landroid/view/ViewGroup$LayoutParams;"
+            )
+            if !params.null?
+              JNIHelpers.with_class(env, "android/widget/LinearLayout$LayoutParams") do |params_class|
+                unless params_class.null?
+                  if env.is_instance_of(params, params_class)
+                    # LinearLayout.LayoutParams exposes `weight` as a public
+                    # float field. The old code looked up a nonexistent
+                    # setWeight method and handed a NULL method id to JNI,
+                    # which aborts the process — a crash on every weighted
+                    # addView. Set the field instead.
+                    fid = env.get_field_id(params_class, "weight", "F")
+                    unless fid.null?
+                      env.set_float_field(params, fid, weight)
+                    end
+                    JNIHelpers.call_void(
+                      env, view.native_ptr, "setLayoutParams",
+                      "(Landroid/view/ViewGroup$LayoutParams;)V", params
+                    )
+                  end
+                end
+              end
+              # The ref returned by getLayoutParams belongs to us.
+              env.delete_local_ref(params)
             end
           end
         end
@@ -138,10 +158,10 @@ module Native::UI
 
     def removeView(view : View)
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0 && view.native_ptr != 0
-        remove_view = env.get_method_id(env.get_object_class(@native), "removeView", "(Landroid/view/View;)V")
-        env.call_void_method(@native, remove_view, view.native_ptr)
+        JNIHelpers.with_env do |env|
+          return if @native == 0 || view.native_ptr == 0
+          JNIHelpers.call_void(env, @native, "removeView", "(Landroid/view/View;)V", view.native_ptr)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.stack_view_remove_view(@native, view.native_ptr)
       {% end %}
@@ -149,10 +169,10 @@ module Native::UI
 
     def removeAllViews
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        remove_all = env.get_method_id(env.get_object_class(@native), "removeAllViews", "()V")
-        env.call_void_method(@native, remove_all)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "removeAllViews", "()V")
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.stack_view_remove_all_views(@native)
       {% end %}
@@ -160,16 +180,16 @@ module Native::UI
 
     def getChildAt(index : Int32) : View?
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return nil unless env && @native != 0
-        get_child = env.get_method_id(env.get_object_class(@native), "getChildAt", "(I)Landroid/view/View;")
-        child_ptr = env.call_object_method(@native, get_child, index)
-        if child_ptr != Pointer(Void).null
-          view = View.new
-          view.native = child_ptr.to_i64
-          view
-        else
-          nil
+        JNIHelpers.with_env do |env|
+          return nil if @native == 0
+          child_ptr = JNIHelpers.call_object(env, @native, "getChildAt", "(I)Landroid/view/View;", index)
+          if !child_ptr.null?
+            view = View.new
+            view.native = child_ptr.to_i64
+            view
+          else
+            nil
+          end
         end
       {% else %}
         nil
@@ -178,20 +198,21 @@ module Native::UI
 
     def childCount : Int32
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return 0 unless env && @native != 0
-        get_count = env.get_method_id(env.get_object_class(@native), "getChildCount", "()I")
-        env.call_int_method(@native, get_count)
+        JNIHelpers.with_env do |env|
+          return 0 if @native == 0
+          JNIHelpers.call_int(env, @native, "getChildCount", "()I")
+        end
       {% else %}
         0
       {% end %}
     end
 
-    private def set_orientation
-      env = Native::Android::JNI.env
-      return unless env && @native != 0
-      set_orientation = env.get_method_id(env.get_object_class(@native), "setOrientation", "(I)V")
-      env.call_void_method(@native, set_orientation, @orientation == Orientation::Vertical ? 1 : 0)
+    private def set_orientation(env : Native::Android::JNIEnvWrapper)
+      {% unless flag?(:native_android) %}
+        return
+      {% end %}
+      return if @native == 0
+      JNIHelpers.call_void(env, @native, "setOrientation", "(I)V", @orientation == Orientation::Vertical ? 1 : 0)
     end
   end
 end

--- a/src/native/framework/ui/progress_bar.cr
+++ b/src/native/framework/ui/progress_bar.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/progress_bar.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class ProgressBar < View
@@ -10,13 +11,12 @@ module Native::UI
       super()
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return unless activity
 
-        progress_class = env.find_class("android/widget/ProgressBar")
-        constructor = env.get_method_id(progress_class, "<init>", "(Landroid/content/Context;)V")
-        @native = env.new_object(progress_class, constructor, activity).to_i64
+          @native = JNIHelpers.new_widget(env, "android/widget/ProgressBar", activity)
+        end
       {% elsif flag?(:native_ios) %}
         ptr = LibIOS.create_progress_view
         @native = ptr.to_i64
@@ -26,10 +26,10 @@ module Native::UI
     def progress=(value : Int32)
       @progress = value.clamp(0, @max)
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_progress = env.get_method_id(env.get_object_class(@native), "setProgress", "(I)V")
-        env.call_void_method(@native, set_progress, @progress)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "setProgress", "(I)V", @progress)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.progress_view_set_progress(@native, @progress, @max)
       {% end %}
@@ -37,10 +37,10 @@ module Native::UI
 
     def progress : Int32
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return @progress unless env && @native != 0
-        get_progress = env.get_method_id(env.get_object_class(@native), "getProgress", "()I")
-        @progress = env.call_int_method(@native, get_progress)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          @progress = JNIHelpers.call_int(env, @native, "getProgress", "()I")
+        end
       {% end %}
       @progress
     end
@@ -48,10 +48,10 @@ module Native::UI
     def max=(value : Int32)
       @max = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_max = env.get_method_id(env.get_object_class(@native), "setMax", "(I)V")
-        env.call_void_method(@native, set_max, @max)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "setMax", "(I)V", @max)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.progress_view_set_max(@native, @max)
       {% end %}
@@ -64,10 +64,10 @@ module Native::UI
     def indeterminate=(value : Bool)
       @indeterminate = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_indeterminate = env.get_method_id(env.get_object_class(@native), "setIndeterminate", "(Z)V")
-        env.call_void_method(@native, set_indeterminate, value)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "setIndeterminate", "(Z)V", value)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.progress_view_set_indeterminate(@native, value)
       {% end %}
@@ -79,11 +79,15 @@ module Native::UI
 
     def horizontal
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        style = env.get_static_field_id(env.find_class("android/R$attr"), "progressBarStyleHorizontal", "I")
-        style_value = env.get_static_int_field(env.find_class("android/R$attr"), style)
-        # Need to recreate with different style
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.with_class(env, "android/R$attr") do |attr_class|
+            return if attr_class.null?
+            style = env.get_static_field_id(attr_class, "progressBarStyleHorizontal", "I")
+            style_value = style.null? ? 0 : env.get_static_int_field(attr_class, style)
+            # Need to recreate with different style
+          end
+        end
       {% end %}
     end
   end
@@ -92,14 +96,27 @@ module Native::UI
     def initialize
       super()
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return unless activity
 
-        progress_class = env.find_class("android/widget/ProgressBar")
-        style = env.get_static_field_id(env.find_class("android/R$attr"), "progressBarStyleLarge", "I")
-        constructor = env.get_method_id(progress_class, "<init>", "(Landroid/content/Context;I)V")
-        @native = env.new_object(progress_class, constructor, activity, style).to_i64
+          # Look up the styled attribute, then build the widget with the
+          # two-arg (Context, style) constructor. Both class refs are
+          # cleaned up by with_class.
+          style = JNIHelpers.with_class(env, "android/R$attr") do |attr_class|
+            next 0 if attr_class.null?
+            fid = env.get_static_field_id(attr_class, "progressBarStyleLarge", "I")
+            fid.null? ? 0 : env.get_static_int_field(attr_class, fid)
+          end
+
+          @native = JNIHelpers.with_class(env, "android/widget/ProgressBar") do |progress_class|
+            next 0i64 if progress_class.null?
+            ctor = env.get_method_id(progress_class, "<init>", "(Landroid/content/Context;I)V")
+            next 0i64 if ctor.null?
+            obj = env.new_object(progress_class, ctor, activity, style)
+            obj.null? ? 0i64 : obj.to_i64
+          end
+        end
       {% end %}
     end
   end

--- a/src/native/framework/ui/radiobutton.cr
+++ b/src/native/framework/ui/radiobutton.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/radiobutton.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class RadioButton < View
@@ -12,18 +13,17 @@ module Native::UI
       @text = text
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return unless activity
 
-        radio_class = env.find_class("android/widget/RadioButton")
-        constructor = env.get_method_id(radio_class, "<init>", "(Landroid/content/Context;)V")
-        @native = env.new_object(radio_class, constructor, activity).to_i64
+          @native = JNIHelpers.new_widget(env, "android/widget/RadioButton", activity)
 
-        if !text.empty?
-          self.text = text
+          if !text.empty?
+            JNIHelpers.set_text(env, @native, text)
+          end
+          setupCheckedListener(env)
         end
-        setupCheckedListener
       {% elsif flag?(:native_ios) %}
         ptr = LibIOS.create_radio_button
         @native = ptr.to_i64
@@ -36,10 +36,10 @@ module Native::UI
     def checked=(value : Bool)
       @checked = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_checked = env.get_method_id(env.get_object_class(@native), "setChecked", "(Z)V")
-        env.call_void_method(@native, set_checked, value)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "setChecked", "(Z)V", value)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.radio_button_set_checked(@native, value)
       {% end %}
@@ -47,10 +47,10 @@ module Native::UI
 
     def checked? : Bool
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return @checked unless env && @native != 0
-        is_checked = env.get_method_id(env.get_object_class(@native), "isChecked", "()Z")
-        @checked = env.call_boolean_method(@native, is_checked)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          @checked = JNIHelpers.call_boolean(env, @native, "isChecked", "()Z")
+        end
       {% elsif flag?(:native_ios) %}
         @checked = LibIOS.radio_button_is_checked(@native)
       {% end %}
@@ -60,11 +60,10 @@ module Native::UI
     def text=(value : String)
       @text = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        jtext = env.new_string_utf(value)
-        set_text = env.get_method_id(env.get_object_class(@native), "setText", "(Ljava/lang/CharSequence;)V")
-        env.call_void_method(@native, set_text, jtext)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.set_text(env, @native, value)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.radio_button_set_text(@native, value.to_utf8)
       {% end %}
@@ -85,11 +84,10 @@ module Native::UI
 
     def text_color=(value : Native::Math::Color)
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        color = ((value.a * 255).to_i << 24) | ((value.r * 255).to_i << 16) | ((value.g * 255).to_i << 8) | (value.b * 255).to_i
-        set_color = env.get_method_id(env.get_object_class(@native), "setTextColor", "(I)V")
-        env.call_void_method(@native, set_color, color)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.set_text_color(env, @native, argb_from_color(value))
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.radio_button_set_text_color(@native, value.r, value.g, value.b)
       {% end %}
@@ -97,10 +95,10 @@ module Native::UI
 
     def text_size=(value : Int32)
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_size = env.get_method_id(env.get_object_class(@native), "setTextSize", "(F)V")
-        env.call_void_method(@native, set_size, value.to_f32)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.set_text_size(env, @native, value)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.radio_button_set_text_size(@native, value)
       {% end %}
@@ -108,24 +106,30 @@ module Native::UI
 
     def on_checked_change(&block : Bool -> Nil)
       @on_checked_change = block
+      {% if flag?(:native_android) %}
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          setupCheckedListener(env)
+        end
+      {% end %}
     end
 
-    private def setupCheckedListener
+    private def setupCheckedListener(env : Native::Android::JNIEnvWrapper)
       {% unless flag?(:native_android) %}
         return
       {% end %}
-      env = Native::Android::JNI.env
-      return unless env && @native != 0
 
-      callback_class = env.find_class("com/nativecr/CompoundButtonCallback")
-      if callback_class == Pointer(Void).null
-        return
+      callback = JNIHelpers.new_callback(env, "com/nativecr/CompoundButtonCallback", 0i64)
+      return if callback.null?
+
+      begin
+        JNIHelpers.call_void(
+          env, @native, "setOnCheckedChangeListener",
+          "(Landroid/widget/CompoundButton$OnCheckedChangeListener;)V", callback
+        )
+      ensure
+        env.delete_local_ref(callback)
       end
-
-      callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
-
-      set_listener = env.get_method_id(env.get_object_class(@native), "setOnCheckedChangeListener", "(Landroid/widget/CompoundButton$OnCheckedChangeListener;)V")
-      env.call_void_method(@native, set_listener, callback_obj)
     end
 
     def handleCheckedChanged(checked : Bool)
@@ -135,6 +139,13 @@ module Native::UI
       if checked && @group
         @group.not_nil!.handleButtonSelected(self)
       end
+    end
+
+    private def argb_from_color(color : Native::Math::Color) : Int32
+      ((color.a * 255).to_i << 24) |
+      ((color.r * 255).to_i << 16) |
+      ((color.g * 255).to_i << 8) |
+      (color.b * 255).to_i
     end
   end
 

--- a/src/native/framework/ui/switch.cr
+++ b/src/native/framework/ui/switch.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/switch.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class Switch < View
@@ -11,15 +12,14 @@ module Native::UI
       super()
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return unless activity
 
-        switch_class = env.find_class("android/widget/Switch")
-        constructor = env.get_method_id(switch_class, "<init>", "(Landroid/content/Context;)V")
-        @native = env.new_object(switch_class, constructor, activity).to_i64
+          @native = JNIHelpers.new_widget(env, "android/widget/Switch", activity)
 
-        setupCheckedListener
+          setupCheckedListener(env)
+        end
       {% elsif flag?(:native_ios) %}
         ptr = LibIOS.create_switch
         @native = ptr.to_i64
@@ -29,10 +29,10 @@ module Native::UI
     def checked=(value : Bool)
       @checked = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_checked = env.get_method_id(env.get_object_class(@native), "setChecked", "(Z)V")
-        env.call_void_method(@native, set_checked, value)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "setChecked", "(Z)V", value)
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.switch_set_on(@native, value)
       {% end %}
@@ -40,10 +40,10 @@ module Native::UI
 
     def checked? : Bool
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return @checked unless env && @native != 0
-        is_checked = env.get_method_id(env.get_object_class(@native), "isChecked", "()Z")
-        @checked = env.call_boolean_method(@native, is_checked)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          @checked = JNIHelpers.call_boolean(env, @native, "isChecked", "()Z")
+        end
       {% elsif flag?(:native_ios) %}
         @checked = LibIOS.switch_is_on(@native)
       {% end %}
@@ -57,11 +57,10 @@ module Native::UI
     def text_on=(value : String)
       @text_on = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        jtext = env.new_string_utf(value)
-        set_text = env.get_method_id(env.get_object_class(@native), "setTextOn", "(Ljava/lang/CharSequence;)V")
-        env.call_void_method(@native, set_text, jtext)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void_string(env, @native, "setTextOn", "(Ljava/lang/CharSequence;)V", value)
+        end
       {% end %}
     end
 
@@ -72,11 +71,10 @@ module Native::UI
     def text_off=(value : String)
       @text_off = value
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        jtext = env.new_string_utf(value)
-        set_text = env.get_method_id(env.get_object_class(@native), "setTextOff", "(Ljava/lang/CharSequence;)V")
-        env.call_void_method(@native, set_text, jtext)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void_string(env, @native, "setTextOff", "(Ljava/lang/CharSequence;)V", value)
+        end
       {% end %}
     end
 
@@ -86,33 +84,39 @@ module Native::UI
 
     def show_text=(value : Bool)
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env && @native != 0
-        set_show = env.get_method_id(env.get_object_class(@native), "setShowText", "(Z)V")
-        env.call_void_method(@native, set_show, value)
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          JNIHelpers.call_void(env, @native, "setShowText", "(Z)V", value)
+        end
       {% end %}
     end
 
     def on_checked_change(&block : Bool -> Nil)
       @on_checked_change = block
+      {% if flag?(:native_android) %}
+        JNIHelpers.with_env do |env|
+          return if @native == 0
+          setupCheckedListener(env)
+        end
+      {% end %}
     end
 
-    private def setupCheckedListener
+    private def setupCheckedListener(env : Native::Android::JNIEnvWrapper)
       {% unless flag?(:native_android) %}
         return
       {% end %}
-      env = Native::Android::JNI.env
-      return unless env && @native != 0
 
-      callback_class = env.find_class("com/nativecr/CompoundButtonCallback")
-      if callback_class == Pointer(Void).null
-        return
+      callback = JNIHelpers.new_callback(env, "com/nativecr/CompoundButtonCallback", 0i64)
+      return if callback.null?
+
+      begin
+        JNIHelpers.call_void(
+          env, @native, "setOnCheckedChangeListener",
+          "(Landroid/widget/CompoundButton$OnCheckedChangeListener;)V", callback
+        )
+      ensure
+        env.delete_local_ref(callback)
       end
-
-      callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
-
-      set_listener = env.get_method_id(env.get_object_class(@native), "setOnCheckedChangeListener", "(Landroid/widget/CompoundButton$OnCheckedChangeListener;)V")
-      env.call_void_method(@native, set_listener, callback_obj)
     end
 
     def handleCheckedChanged(checked : Bool)


### PR DESCRIPTION
## Part 1 of framework-pre1.0: JNI engine foundation + first migration batch

Follows the JNIHelpers refactor direction already present in view.cr / text_view.cr / button.cr / seek_bar.cr.

### Engine fixes (all slot indexes verified against OpenJDK `jni.h` `JNINativeInterface_`)
- **Table misalignment (+4) fixed**: a phantom `Void*[4]` gap sat between `ReleaseStringUTFChars` (170) and `GetArrayLength` (171), shifting every array function into the wrong slot — `new_byte_array` bound to `NewIntArray`, `get/set_byte_array_region` to float/double region functions. Every byte-array user (audio, camera) was one wrong-type call from a JNI abort.
- **Missing slots spliced in**: `CallLongMethodA` (54), `CallDoubleMethodA` (60), `CallStaticFloatMethodA` (137), `ExceptionOccurred/Describe/Clear` (15-17), `ExceptionCheck` (228), long/float/double instance + static field accessors (101-103, 110-112, 151-153).
- **Stubs made real**: `JNI.call_long_method`/`call_double_method` were hardcoded `0` — durations, sizes, timestamps all read 0. Wrapper `call_long_method`/`call_double_method` likewise.
- **Exception API**: pending JNI exceptions make all subsequent JNI calls UB; `exception_check/clear/occurred` added to the table, JNI and the wrapper.

### JNIHelpers completion
`call_boolean`, `call_long`, `call_double`, `call_string` (reads + deletes the returned ref), `call_static_int/boolean/float`.

### Framework migration batch 1 (method surface unchanged, verified by diff)
`checkbox`, `switch`, `progress_bar` + `CircularProgressBar`, `radiobutton`, `linear_layout` — from raw `env.*` calls (leaking a local ref per `find_class` / `get_object_class` / `new_string_utf`) to the `JNIHelpers` style.

Plus one real crash fix found during migration: `linear_layout#addView(weight > 0)` looked up the nonexistent `LinearLayout.LayoutParams#setWeight` and passed a NULL method id to JNI (process abort). The real public `weight` float field is now set via the new field accessors.

### Remaining for this branch (next batches)
media (audio/camera/video), storage, platform, notifications, network, biometric, sensors, location, payment, permissions, share, clipboard, connectivity, image_picker, toolbar, dialogs, web_view, recycler_view, scroll_view, spinner, edit_text, icon, card_view, image_view, animation.

**Note**: if you have unpushed local WIP on the same files, push it and I will rebase this onto it — nothing here is precious.
