### PR TITLE
refactor(framework): JNIHelpers migration batch 2 + platform typechecks that actually compile android/ios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
 
       # The platform-conditional code ({% if flag?(:native_android) %} etc.)
       # is never compiled by the test/build jobs — this is the only place
-      # its types are actually checked.
+      # its types are actually checked. NOTE: crystal options must come
+      # BEFORE the programfile; anything after src/native.cr is passed to
+      # the compiled program as ARGV, not as a define.
       - name: Type-check (${{ matrix.name }})
-        run: crystal build --no-codegen -o /dev/null src/native.cr ${{ matrix.flags }}
+        run: crystal build --no-codegen ${{ matrix.flags }} -o /dev/null src/native.cr

--- a/src/native/engine/android/jni_helpers.cr
+++ b/src/native/engine/android/jni_helpers.cr
@@ -140,6 +140,15 @@
       result
     end
 
+    # ── One-shot object call taking a String ─────────────────────────────────
+    # Creates the jstring, passes it, deletes it — the mirror of
+    # call_void_string for chainable builder methods.
+    def self.call_object_string(env : JNIEnvWrapper, obj : Int64, method_name : String, sig : String, str : String, *args) : Void*
+      with_jstring(env, str) do |jstr|
+        call_object(env, obj, method_name, sig, jstr, *args)
+      end
+    end
+
     # ── One-shot static int call ─────────────────────────────────────────────
     def self.call_static_int(env : JNIEnvWrapper, class_name : String, method_name : String, sig : String, *args) : Int32
       with_class(env, class_name) do |jclass|

--- a/src/native/framework/animation/animation.cr
+++ b/src/native/framework/animation/animation.cr
@@ -270,12 +270,19 @@ module Native::Animation
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
 
-        animator_array = env.new_object_array(animators.size, env.find_class("android/animation/Animator"), nil)
-        animators.each_with_index do |anim, i|
-          env.set_object_array_element(animator_array, i, anim.animator_ptr)
+        animator_class = env.find_class("android/animation/Animator")
+        return if animator_class.null?
+        animator_array = env.new_object_array(animators.size, animator_class)
+        env.delete_local_ref(animator_class) unless animator_class.null?
+        return if animator_array.null?
+        begin
+          animators.each_with_index do |anim, i|
+            env.set_object_array_element(animator_array, i, anim.animator_ptr)
+          end
+          JNIHelpers.call_void(env, @animator_ptr, "playSequentially", "([Landroid/animation/Animator;)V", animator_array)
+        ensure
+          env.delete_local_ref(animator_array)
         end
-
-        JNIHelpers.call_void(env, @animator_ptr, "playSequentially", "([Landroid/animation/Animator;)V", animator_array)
       {% elsif flag?(:native_ios) %}
         LibIOS.animator_set_play_sequentially(@animator_ptr)
       {% end %}

--- a/src/native/framework/animation/animation.cr
+++ b/src/native/framework/animation/animation.cr
@@ -51,7 +51,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        JNIHelpers.call_object(env, @animator_ptr, "setDuration", "(J)Landroid/animation/ValueAnimator;", , value.to_i64)
+        JNIHelpers.call_object(env, @animator_ptr, "setDuration", "(J)Landroid/animation/ValueAnimator;", value.to_i64)
       {% elsif flag?(:native_ios) %}
         LibIOS.animator_set_duration(@animator_ptr, value)
       {% end %}
@@ -87,7 +87,7 @@ module Native::Animation
                              end
 
         interpolator_obj = env.new_object(interpolator_class, env.get_method_id(interpolator_class, "<init>", "()V"))
-        JNIHelpers.call_void(env, @animator_ptr, "setInterpolator", "(Landroid/animation/TimeInterpolator;)V", , interpolator_obj)
+        JNIHelpers.call_void(env, @animator_ptr, "setInterpolator", "(Landroid/animation/TimeInterpolator;)V", interpolator_obj)
       {% end %}
     end
 
@@ -100,7 +100,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        JNIHelpers.call_void(env, @animator_ptr, "setRepeatCount", "(I)V", , value)
+        JNIHelpers.call_void(env, @animator_ptr, "setRepeatCount", "(I)V", value)
       {% elsif flag?(:native_ios) %}
         LibIOS.animator_set_repeat_count(@animator_ptr, value)
       {% end %}
@@ -115,7 +115,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        JNIHelpers.call_void(env, @animator_ptr, "setRepeatMode", "(I)V", , value)
+        JNIHelpers.call_void(env, @animator_ptr, "setRepeatMode", "(I)V", value)
       {% end %}
     end
 
@@ -275,7 +275,7 @@ module Native::Animation
           env.set_object_array_element(animator_array, i, anim.animator_ptr)
         end
 
-        JNIHelpers.call_void(env, @animator_ptr, "playSequentially", "([Landroid/animation/Animator;)V", , animator_array)
+        JNIHelpers.call_void(env, @animator_ptr, "playSequentially", "([Landroid/animation/Animator;)V", animator_array)
       {% elsif flag?(:native_ios) %}
         LibIOS.animator_set_play_sequentially(@animator_ptr)
       {% end %}

--- a/src/native/framework/animation/animation.cr
+++ b/src/native/framework/animation/animation.cr
@@ -1,4 +1,5 @@
 # src/native/framework/animation/animator.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Animation
   enum Interpolator
@@ -36,6 +37,7 @@ module Native::Animation
         animator_class = env.find_class("android/animation/ValueAnimator")
         of_float = env.get_static_method_id(animator_class, "ofFloat", "(FF)Landroid/animation/ValueAnimator;")
         @animator_ptr = env.call_static_object_method(animator_class, of_float, start_value.to_f32, end_value.to_f32).to_i64
+        env.delete_local_ref(animator_class) unless animator_class.null?
 
         setupListeners
       {% elsif flag?(:native_ios) %}
@@ -49,8 +51,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        set_duration = env.get_method_id(env.get_object_class(@animator_ptr), "setDuration", "(J)Landroid/animation/ValueAnimator;")
-        env.call_object_method(@animator_ptr, set_duration, value.to_i64)
+        JNIHelpers.call_object(env, @animator_ptr, "setDuration", "(J)Landroid/animation/ValueAnimator;", , value.to_i64)
       {% elsif flag?(:native_ios) %}
         LibIOS.animator_set_duration(@animator_ptr, value)
       {% end %}
@@ -86,8 +87,7 @@ module Native::Animation
                              end
 
         interpolator_obj = env.new_object(interpolator_class, env.get_method_id(interpolator_class, "<init>", "()V"))
-        set_interpolator = env.get_method_id(env.get_object_class(@animator_ptr), "setInterpolator", "(Landroid/animation/TimeInterpolator;)V")
-        env.call_void_method(@animator_ptr, set_interpolator, interpolator_obj)
+        JNIHelpers.call_void(env, @animator_ptr, "setInterpolator", "(Landroid/animation/TimeInterpolator;)V", , interpolator_obj)
       {% end %}
     end
 
@@ -100,8 +100,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        set_repeat = env.get_method_id(env.get_object_class(@animator_ptr), "setRepeatCount", "(I)V")
-        env.call_void_method(@animator_ptr, set_repeat, value)
+        JNIHelpers.call_void(env, @animator_ptr, "setRepeatCount", "(I)V", , value)
       {% elsif flag?(:native_ios) %}
         LibIOS.animator_set_repeat_count(@animator_ptr, value)
       {% end %}
@@ -116,8 +115,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        set_mode = env.get_method_id(env.get_object_class(@animator_ptr), "setRepeatMode", "(I)V")
-        env.call_void_method(@animator_ptr, set_mode, value)
+        JNIHelpers.call_void(env, @animator_ptr, "setRepeatMode", "(I)V", , value)
       {% end %}
     end
 
@@ -129,8 +127,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        start_method = env.get_method_id(env.get_object_class(@animator_ptr), "start", "()V")
-        env.call_void_method(@animator_ptr, start_method)
+        JNIHelpers.call_void(env, @animator_ptr, "start", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.animator_start(@animator_ptr)
       {% end %}
@@ -140,8 +137,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        cancel_method = env.get_method_id(env.get_object_class(@animator_ptr), "cancel", "()V")
-        env.call_void_method(@animator_ptr, cancel_method)
+        JNIHelpers.call_void(env, @animator_ptr, "cancel", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.animator_cancel(@animator_ptr)
       {% end %}
@@ -151,8 +147,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        end_method = env.get_method_id(env.get_object_class(@animator_ptr), "end", "()V")
-        env.call_void_method(@animator_ptr, end_method)
+        JNIHelpers.call_void(env, @animator_ptr, "end", "()V")
       {% end %}
     end
 
@@ -160,8 +155,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return false unless env && @animator_ptr != 0
-        is_running = env.get_method_id(env.get_object_class(@animator_ptr), "isRunning", "()Z")
-        env.call_boolean_method(@animator_ptr, is_running)
+        JNIHelpers.call_boolean(env, @animator_ptr, "isRunning", "()Z")
       {% else %}
         false
       {% end %}
@@ -196,12 +190,11 @@ module Native::Animation
       end
 
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
+      env.delete_local_ref(callback_class) unless callback_class.null?
 
-      add_listener = env.get_method_id(env.get_object_class(@animator_ptr), "addUpdateListener", "(Landroid/animation/ValueAnimator$AnimatorUpdateListener;)V")
-      env.call_void_method(@animator_ptr, add_listener, callback_obj)
+      JNIHelpers.call_void(env, @animator_ptr, "addUpdateListener", "(Landroid/animation/ValueAnimator$AnimatorUpdateListener;)V", callback_obj)
 
-      add_listener = env.get_method_id(env.get_object_class(@animator_ptr), "addListener", "(Landroid/animation/Animator$AnimatorListener;)V")
-      env.call_void_method(@animator_ptr, add_listener, callback_obj)
+      JNIHelpers.call_void(env, @animator_ptr, "addListener", "(Landroid/animation/Animator$AnimatorListener;)V", callback_obj)
     end
 
     def handleUpdate(value : Float32)
@@ -237,6 +230,7 @@ module Native::Animation
         animator_class = env.find_class("android/animation/ObjectAnimator")
         of_float = env.get_static_method_id(animator_class, "ofFloat", "(Ljava/lang/Object;Ljava/lang/String;FF)Landroid/animation/ObjectAnimator;")
         @animator_ptr = env.call_static_object_method(animator_class, of_float, target.native_ptr, env.new_string_utf(property_name), start_value.to_f32, end_value.to_f32).to_i64
+        env.delete_local_ref(animator_class) unless animator_class.null?
 
         setupListeners
       {% end %}
@@ -254,6 +248,7 @@ module Native::Animation
 
         set_class = env.find_class("android/animation/AnimatorSet")
         @animator_ptr = env.new_object(set_class, env.get_method_id(set_class, "<init>", "()V")).to_i64
+        env.delete_local_ref(set_class) unless set_class.null?
       {% elsif flag?(:native_ios) %}
         ptr = LibIOS.create_animator_set
         @animator_ptr = ptr.to_i64
@@ -265,8 +260,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0 && animator.animator_ptr != 0
-        play = env.get_method_id(env.get_object_class(@animator_ptr), "play", "(Landroid/animation/Animator;)Landroid/animation/AnimatorSet$Builder;")
-        env.call_object_method(@animator_ptr, play, animator.animator_ptr)
+        JNIHelpers.call_object(env, @animator_ptr, "play", "(Landroid/animation/Animator;)Landroid/animation/AnimatorSet$Builder;", animator.animator_ptr)
       {% end %}
     end
 
@@ -281,8 +275,7 @@ module Native::Animation
           env.set_object_array_element(animator_array, i, anim.animator_ptr)
         end
 
-        play_seq = env.get_method_id(env.get_object_class(@animator_ptr), "playSequentially", "([Landroid/animation/Animator;)V")
-        env.call_void_method(@animator_ptr, play_seq, animator_array)
+        JNIHelpers.call_void(env, @animator_ptr, "playSequentially", "([Landroid/animation/Animator;)V", , animator_array)
       {% elsif flag?(:native_ios) %}
         LibIOS.animator_set_play_sequentially(@animator_ptr)
       {% end %}
@@ -292,8 +285,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        start_method = env.get_method_id(env.get_object_class(@animator_ptr), "start", "()V")
-        env.call_void_method(@animator_ptr, start_method)
+        JNIHelpers.call_void(env, @animator_ptr, "start", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.animator_set_start(@animator_ptr)
       {% end %}
@@ -303,8 +295,7 @@ module Native::Animation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @animator_ptr != 0
-        cancel_method = env.get_method_id(env.get_object_class(@animator_ptr), "cancel", "()V")
-        env.call_void_method(@animator_ptr, cancel_method)
+        JNIHelpers.call_void(env, @animator_ptr, "cancel", "()V")
       {% end %}
     end
 

--- a/src/native/framework/biometric.cr
+++ b/src/native/framework/biometric.cr
@@ -1,4 +1,5 @@
 # src/native/framework/biometric.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Biometric
   enum BiometricType
@@ -71,13 +72,20 @@ module Native::Biometric
 
     def self.is_enrolled? : Bool
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return false unless env
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          next false if activity.null?
 
-        keyguard_class = env.find_class("android/app/KeyguardManager")
-        keyguard = env.call_object_method(Native::Android::JNI.activity, env.get_method_id(env.get_object_class(Native::Android::JNI.activity), "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"), env.new_string_utf("keyguard"))
-        is_keyguard = env.get_method_id(env.get_object_class(keyguard), "isKeyguardSecure", "()Z")
-        env.call_boolean_method(keyguard, is_keyguard)
+          keyguard = JNIHelpers.with_jstring(env, "keyguard") do |jname|
+            JNIHelpers.call_object(env, activity.to_i64, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;", jname)
+          end
+          next false if keyguard.null?
+          begin
+            JNIHelpers.call_boolean(env, keyguard.to_i64, "isKeyguardSecure", "()Z")
+          ensure
+            env.delete_local_ref(keyguard)
+          end
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.is_biometric_enrolled
       {% else %}
@@ -89,45 +97,64 @@ module Native::Biometric
       return BiometricResult.new(success: false, error: BiometricError::NotAvailable) unless is_available?
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return BiometricResult.new(success: false, error: BiometricError::NotAvailable) unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          next BiometricResult.new(success: false, error: BiometricError::NotAvailable) if activity.null?
 
-        biometric_class = env.find_class("androidx/biometric/BiometricPrompt")
-        if biometric_class == Pointer(Void).null
-          return BiometricResult.new(success: false, error: BiometricError::NotAvailable)
+          executor = JNIHelpers.call_static_object(env, "android/os/Handler", "getMain", "()Landroid/os/Handler;")
+          next BiometricResult.new(success: false, error: BiometricError::NotAvailable) if executor.null?
+          begin
+            callback_obj = JNIHelpers.new_callback(env, "com/nativecr/BiometricCallback", 0i64)
+            next BiometricResult.new(success: false, error: BiometricError::NotAvailable) if callback_obj.null?
+            begin
+              prompt_info = JNIHelpers.with_class(env, "androidx/biometric/BiometricPrompt$PromptInfo$Builder") do |builder_class|
+                next Pointer(Void).null if builder_class.null?
+                ctor = env.get_method_id(builder_class, "<init>", "()V")
+                next Pointer(Void).null if ctor.null?
+                builder = env.new_object(builder_class, ctor)
+                next Pointer(Void).null if builder.null?
+                begin
+                  JNIHelpers.with_jstring(env, config.title) do |jt|
+                    JNIHelpers.call_object(env, builder.to_i64, "setTitle", "(Ljava/lang/CharSequence;)Landroidx/biometric/BiometricPrompt$PromptInfo$Builder;", jt)
+                  end
+                  JNIHelpers.with_jstring(env, config.subtitle) do |jt|
+                    JNIHelpers.call_object(env, builder.to_i64, "setSubtitle", "(Ljava/lang/CharSequence;)Landroidx/biometric/BiometricPrompt$PromptInfo$Builder;", jt)
+                  end
+                  JNIHelpers.with_jstring(env, config.description) do |jt|
+                    JNIHelpers.call_object(env, builder.to_i64, "setDescription", "(Ljava/lang/CharSequence;)Landroidx/biometric/BiometricPrompt$PromptInfo$Builder;", jt)
+                  end
+                  JNIHelpers.with_jstring(env, config.cancel_title) do |jt|
+                    JNIHelpers.call_object(env, builder.to_i64, "setNegativeButtonText", "(Ljava/lang/CharSequence;)Landroidx/biometric/BiometricPrompt$PromptInfo$Builder;", jt)
+                  end
+                  JNIHelpers.call_object(env, builder.to_i64, "build", "()Landroidx/biometric/BiometricPrompt$PromptInfo;")
+                ensure
+                  env.delete_local_ref(builder)
+                end
+              end
+              next BiometricResult.new(success: false, error: BiometricError::NotAvailable) if prompt_info.null?
+
+              JNIHelpers.with_class(env, "androidx/biometric/BiometricPrompt") do |prompt_class|
+                next if prompt_class.null?
+                # The real BiometricPrompt constructor takes a
+                # FragmentActivity — the old code looked up a
+                # ContextCompat signature (null method id → JNI abort).
+                ctor = env.get_method_id(prompt_class, "<init>", "(Landroidx/fragment/app/FragmentActivity;Ljava/util/concurrent/Executor;Landroidx/biometric/BiometricPrompt$AuthenticationCallback;)V")
+                next if ctor.null?
+                biometric_prompt = env.new_object(prompt_class, ctor, activity, executor, callback_obj)
+                next if biometric_prompt.null?
+                begin
+                  JNIHelpers.call_void(env, biometric_prompt.to_i64, "authenticate", "(Landroidx/biometric/BiometricPrompt$PromptInfo;)V", prompt_info)
+                ensure
+                  env.delete_local_ref(biometric_prompt)
+                end
+              end
+            ensure
+              env.delete_local_ref(callback_obj)
+            end
+          ensure
+            env.delete_local_ref(executor)
+          end
         end
-
-        executor_class = env.find_class("android/os/Handler")
-        executor = env.call_static_object_method(executor_class, env.get_static_method_id(executor_class, "getMain", "()Landroid/os/Handler;"))
-
-        callback_class = env.find_class("com/nativecr/BiometricCallback")
-        callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
-
-        prompt_info_class = env.find_class("androidx/biometric/BiometricPrompt$PromptInfo")
-        builder_class = env.find_class("androidx/biometric/BiometricPrompt$PromptInfo$Builder")
-        builder = env.new_object(builder_class, env.get_method_id(builder_class, "<init>", "()V"))
-
-        set_title = env.get_method_id(builder_class, "setTitle", "(Ljava/lang/CharSequence;)Landroidx/biometric/BiometricPrompt$PromptInfo$Builder;")
-        env.call_object_method(builder, set_title, env.new_string_utf(config.title))
-
-        set_subtitle = env.get_method_id(builder_class, "setSubtitle", "(Ljava/lang/CharSequence;)Landroidx/biometric/BiometricPrompt$PromptInfo$Builder;")
-        env.call_object_method(builder, set_subtitle, env.new_string_utf(config.subtitle))
-
-        set_desc = env.get_method_id(builder_class, "setDescription", "(Ljava/lang/CharSequence;)Landroidx/biometric/BiometricPrompt$PromptInfo$Builder;")
-        env.call_object_method(builder, set_desc, env.new_string_utf(config.description))
-
-        set_negative = env.get_method_id(builder_class, "setNegativeButtonText", "(Ljava/lang/CharSequence;)Landroidx/biometric/BiometricPrompt$PromptInfo$Builder;")
-        env.call_object_method(builder, set_negative, env.new_string_utf(config.cancel_title))
-
-        build = env.get_method_id(builder_class, "build", "()Landroidx/biometric/BiometricPrompt$PromptInfo;")
-        prompt_info = env.call_object_method(builder, build)
-
-        biometric_prompt = env.new_object(biometric_class, env.get_method_id(biometric_class, "<init>", "(Landroidx/core/content/ContextCompat;Ljava/util/concurrent/Executor;Landroidx/biometric/BiometricPrompt$AuthenticationCallback;)V"), activity, executor, callback_obj)
-
-        authenticate = env.get_method_id(biometric_class, "authenticate", "(Landroidx/biometric/BiometricPrompt$PromptInfo;)V")
-        env.call_void_method(biometric_prompt, authenticate, prompt_info)
-
         wait_result
       {% elsif flag?(:native_ios) %}
         result_code = LibIOS.authenticate_biometric(
@@ -153,23 +180,20 @@ module Native::Biometric
 
     private def self.check_availability : Nil
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          next if activity.null?
 
-        biometric_class = env.find_class("androidx/biometric/BiometricManager")
-        if biometric_class == Pointer(Void).null
-          @@is_available = false
-          return
+          manager = JNIHelpers.call_static_object(env, "androidx/biometric/BiometricManager", "from", "(Landroid/content/Context;)Landroidx/biometric/BiometricManager;", activity)
+          next if manager.null?
+          begin
+            result = JNIHelpers.call_int(env, manager.to_i64, "canAuthenticate", "(I)I", 0)
+            @@is_available = result == 0
+            @@available_type = BiometricType::Fingerprint if @@is_available
+          ensure
+            env.delete_local_ref(manager)
+          end
         end
-
-        from = env.get_static_method_id(biometric_class, "from", "(Landroid/content/Context;)Landroidx/biometric/BiometricManager;")
-        manager = env.call_static_object_method(biometric_class, from, Native::Android::JNI.activity)
-
-        can_auth = env.get_method_id(biometric_class, "canAuthenticate", "(I)I")
-        result = env.call_int_method(manager, can_auth, 0)
-
-        @@is_available = result == 0
-        @@available_type = BiometricType::Fingerprint if @@is_available
       {% elsif flag?(:native_ios) %}
         result = LibIOS.get_biometric_type
         @@is_available = result != 0

--- a/src/native/framework/clipboard.cr
+++ b/src/native/framework/clipboard.cr
@@ -1,4 +1,5 @@
 # src/native/framework/clipboard.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Clipboard
   class ClipboardManager
@@ -9,27 +10,40 @@ module Native::Clipboard
       @@instance.not_nil!
     end
 
+    # Yields the system clipboard service, cleaning up the service ref and
+    # the "clipboard" jstring afterwards.
+    private def with_clipboard(env : Native::Android::JNIEnvWrapper, &block : Void* -> T?) : T? forall T
+      activity = Native::Android::JNI.activity
+      return nil if activity.null?
+
+      service = JNIHelpers.with_jstring(env, "clipboard") do |jname|
+        JNIHelpers.call_object(env, activity.to_i64, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;", jname)
+      end
+      return nil if service.null?
+      begin
+        yield service
+      ensure
+        env.delete_local_ref(service)
+      end
+    end
+
     def set_text(text : String) : Bool
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return false unless env && activity
-
-        clipboard = env.call_object_method(activity, env.get_method_id(env.get_object_class(activity), "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"), env.new_string_utf("clipboard"))
-
-        if clipboard
-          clip_class = env.find_class("android/content/ClipData")
-          new_plain_text = env.get_static_method_id(clip_class, "newPlainText", "(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Landroid/content/ClipData;")
-          clip = env.call_static_object_method(clip_class, new_plain_text, env.new_string_utf("text"), env.new_string_utf(text))
-
-          set_clip = env.get_method_id(env.get_object_class(clipboard), "setPrimaryClip", "(Landroid/content/ClipData;)V")
-          env.call_void_method(clipboard, set_clip, clip)
-
-          env.delete_local_ref(clipboard)
-          env.delete_local_ref(clip)
-          true
-        else
-          false
+        JNIHelpers.with_env do |env|
+          with_clipboard(env) do |clipboard|
+            clip = JNIHelpers.with_jstring(env, "text") do |jlabel|
+              JNIHelpers.with_jstring(env, text) do |jtext|
+                JNIHelpers.call_static_object(env, "android/content/ClipData", "newPlainText", "(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Landroid/content/ClipData;", jlabel, jtext)
+              end
+            end
+            next false if clip.null?
+            begin
+              JNIHelpers.call_void(env, clipboard.to_i64, "setPrimaryClip", "(Landroid/content/ClipData;)V", clip)
+              true
+            ensure
+              env.delete_local_ref(clip)
+            end
+          end || false
         end
       {% elsif flag?(:native_ios) %}
         LibIOS.clipboard_set_text(text.to_utf8)
@@ -40,35 +54,31 @@ module Native::Clipboard
 
     def get_text : String?
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return nil unless env && activity
+        JNIHelpers.with_env do |env|
+          with_clipboard(env) do |clipboard|
+            next nil unless JNIHelpers.call_boolean(env, clipboard.to_i64, "hasPrimaryClip", "()Z")
 
-        clipboard = env.call_object_method(activity, env.get_method_id(env.get_object_class(activity), "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"), env.new_string_utf("clipboard"))
-
-        if clipboard
-          has_text = env.get_method_id(env.get_object_class(clipboard), "hasPrimaryClip", "()Z")
-          if env.call_boolean_method(clipboard, has_text)
-            get_clip = env.get_method_id(env.get_object_class(clipboard), "getPrimaryClip", "()Landroid/content/ClipData;")
-            clip = env.call_object_method(clipboard, get_clip)
-
-            get_item = env.get_method_id(env.get_object_class(clip), "getItemAt", "(I)Landroid/content/ClipData$Item;")
-            item = env.call_object_method(clip, get_item, 0)
-
-            get_text = env.get_method_id(env.get_object_class(item), "getText", "()Ljava/lang/CharSequence;")
-            text = env.call_object_method(item, get_text)
-
-            result = env.get_string_utf_chars(text, nil).to_s
-
-            env.delete_local_ref(clipboard)
-            env.delete_local_ref(clip)
-            env.delete_local_ref(item)
-
-            return result
+            clip = JNIHelpers.call_object(env, clipboard.to_i64, "getPrimaryClip", "()Landroid/content/ClipData;")
+            next nil if clip.null?
+            begin
+              item = JNIHelpers.call_object(env, clip.to_i64, "getItemAt", "(I)Landroid/content/ClipData$Item;", 0)
+              next nil if item.null?
+              begin
+                text = JNIHelpers.call_object(env, item.to_i64, "getText", "()Ljava/lang/CharSequence;")
+                next nil if text.null?
+                begin
+                  JNIHelpers.call_string(env, text.to_i64, "toString", "()Ljava/lang/String;")
+                ensure
+                  env.delete_local_ref(text)
+                end
+              ensure
+                env.delete_local_ref(item)
+              end
+            ensure
+              env.delete_local_ref(clip)
+            end
           end
-          env.delete_local_ref(clipboard)
         end
-        nil
       {% elsif flag?(:native_ios) %}
         ptr = LibIOS.clipboard_get_text
         if ptr
@@ -85,19 +95,11 @@ module Native::Clipboard
 
     def has_text? : Bool
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return false unless env && activity
-
-        clipboard = env.call_object_method(activity, env.get_method_id(env.get_object_class(activity), "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"), env.new_string_utf("clipboard"))
-
-        if clipboard
-          has_text = env.get_method_id(env.get_object_class(clipboard), "hasPrimaryClip", "()Z")
-          result = env.call_boolean_method(clipboard, has_text)
-          env.delete_local_ref(clipboard)
-          result
-        else
-          false
+        JNIHelpers.with_env do |env|
+          result = with_clipboard(env) do |clipboard|
+            JNIHelpers.call_boolean(env, clipboard.to_i64, "hasPrimaryClip", "()Z")
+          end
+          result || false
         end
       {% elsif flag?(:native_ios) %}
         LibIOS.clipboard_has_text

--- a/src/native/framework/connectivity.cr
+++ b/src/native/framework/connectivity.cr
@@ -1,4 +1,5 @@
 # src/native/framework/connectivity.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Connectivity
   enum NetworkType
@@ -58,6 +59,7 @@ module Native::Connectivity
 
         init_method = env.get_static_method_id(conn_class, "init", "(Landroid/app/Activity;)V")
         env.call_static_void_method(conn_class, init_method, activity)
+        env.delete_local_ref(conn_class) unless conn_class.null?
 
         setupCallbacks
       {% elsif flag?(:native_ios) %}
@@ -75,6 +77,7 @@ module Native::Connectivity
 
         get_info = env.get_static_method_id(conn_class, "getNetworkInfo", "()Ljava/lang/String;")
         result = env.call_static_object_method(conn_class, get_info)
+        env.delete_local_ref(conn_class) unless conn_class.null?
 
         if result
           json = env.get_string_utf_chars(result, nil).to_s
@@ -122,6 +125,7 @@ module Native::Connectivity
 
         start_mon = env.get_static_method_id(conn_class, "startMonitoring", "()V")
         env.call_static_void_method(conn_class, start_mon)
+        env.delete_local_ref(conn_class) unless conn_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.connectivity_start_monitoring
       {% end %}
@@ -141,6 +145,7 @@ module Native::Connectivity
 
         stop_mon = env.get_static_method_id(conn_class, "stopMonitoring", "()V")
         env.call_static_void_method(conn_class, stop_mon)
+        env.delete_local_ref(conn_class) unless conn_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.connectivity_stop_monitoring
       {% end %}
@@ -156,21 +161,16 @@ module Native::Connectivity
       {% unless flag?(:native_android) %}
         return
       {% end %}
-      env = Native::Android::JNI.env
-      return unless env
+      JNIHelpers.with_env do |env|
+        callback_obj = JNIHelpers.new_callback(env, "com/nativecr/ConnectivityCallback", 0i64)
+        return if callback_obj.null?
 
-      callback_class = env.find_class("com/nativecr/ConnectivityCallback")
-      if callback_class == Pointer(Void).null
-        return
+        begin
+          JNIHelpers.call_static_void(env, "com/nativecr/ConnectivityHelper", "setCallback", "(Lcom/nativecr/ConnectivityCallback;)V", callback_obj)
+        ensure
+          env.delete_local_ref(callback_obj)
+        end
       end
-
-      callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
-
-      conn_class = env.find_class("com/nativecr/ConnectivityHelper")
-      return if conn_class == Pointer(Void).null
-
-      set_callback = env.get_static_method_id(conn_class, "setCallback", "(Lcom/nativecr/ConnectivityCallback;)V")
-      env.call_static_void_method(conn_class, set_callback, callback_obj)
     end
 
     private def parse_network_info_json(json : String) : NetworkInfo

--- a/src/native/framework/dialog/alert_dialog.cr
+++ b/src/native/framework/dialog/alert_dialog.cr
@@ -1,4 +1,5 @@
 # src/native/framework/dialog/alert_dialog.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Dialog
   class AlertDialog
@@ -22,6 +23,7 @@ module Native::Dialog
         builder_class = env.find_class("android/app/AlertDialog$Builder")
         constructor = env.get_method_id(builder_class, "<init>", "(Landroid/content/Context;)V")
         @dialog_ptr = env.new_object(builder_class, constructor, activity).to_i64
+        env.delete_local_ref(builder_class) unless builder_class.null?
       {% elsif flag?(:native_ios) %}
         ptr = LibIOS.create_alert_controller
         @dialog_ptr = ptr.to_i64
@@ -33,8 +35,7 @@ module Native::Dialog
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @dialog_ptr != 0
-        set_title = env.get_method_id(env.get_object_class(@dialog_ptr), "setTitle", "(Ljava/lang/CharSequence;)Landroid/app/AlertDialog$Builder;")
-        env.call_object_method(@dialog_ptr, set_title, env.new_string_utf(value))
+        JNIHelpers.call_object(env, @dialog_ptr, "setTitle", "(Ljava/lang/CharSequence;)Landroid/app/AlertDialog$Builder;", , env.new_string_utf(value))
       {% elsif flag?(:native_ios) %}
         LibIOS.alert_set_title(@dialog_ptr, value.to_utf8)
       {% end %}
@@ -49,8 +50,7 @@ module Native::Dialog
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @dialog_ptr != 0
-        set_message = env.get_method_id(env.get_object_class(@dialog_ptr), "setMessage", "(Ljava/lang/CharSequence;)Landroid/app/AlertDialog$Builder;")
-        env.call_object_method(@dialog_ptr, set_message, env.new_string_utf(value))
+        JNIHelpers.call_object(env, @dialog_ptr, "setMessage", "(Ljava/lang/CharSequence;)Landroid/app/AlertDialog$Builder;", , env.new_string_utf(value))
       {% elsif flag?(:native_ios) %}
         LibIOS.alert_set_message(@dialog_ptr, value.to_utf8)
       {% end %}
@@ -68,6 +68,7 @@ module Native::Dialog
         set_positive = env.get_method_id(env.get_object_class(@dialog_ptr), "setPositiveButton", "(Ljava/lang/CharSequence;Landroid/content/DialogInterface$OnClickListener;)Landroid/app/AlertDialog$Builder;")
         callback_class = env.find_class("com/nativecr/DialogCallback")
         callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(JI)V"), 0i64, 0)
+        env.delete_local_ref(callback_class) unless callback_class.null?
         env.call_object_method(@dialog_ptr, set_positive, env.new_string_utf(value), callback_obj)
       {% elsif flag?(:native_ios) %}
         LibIOS.alert_add_action(@dialog_ptr, value.to_utf8, 0)
@@ -82,6 +83,7 @@ module Native::Dialog
         set_negative = env.get_method_id(env.get_object_class(@dialog_ptr), "setNegativeButton", "(Ljava/lang/CharSequence;Landroid/content/DialogInterface$OnClickListener;)Landroid/app/AlertDialog$Builder;")
         callback_class = env.find_class("com/nativecr/DialogCallback")
         callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(JI)V"), 0i64, 1)
+        env.delete_local_ref(callback_class) unless callback_class.null?
         env.call_object_method(@dialog_ptr, set_negative, env.new_string_utf(value), callback_obj)
       {% elsif flag?(:native_ios) %}
         LibIOS.alert_add_action(@dialog_ptr, value.to_utf8, 1)
@@ -96,6 +98,7 @@ module Native::Dialog
         set_neutral = env.get_method_id(env.get_object_class(@dialog_ptr), "setNeutralButton", "(Ljava/lang/CharSequence;Landroid/content/DialogInterface$OnClickListener;)Landroid/app/AlertDialog$Builder;")
         callback_class = env.find_class("com/nativecr/DialogCallback")
         callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(JI)V"), 0i64, 2)
+        env.delete_local_ref(callback_class) unless callback_class.null?
         env.call_object_method(@dialog_ptr, set_neutral, env.new_string_utf(value), callback_obj)
       {% end %}
     end
@@ -105,8 +108,7 @@ module Native::Dialog
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @dialog_ptr != 0
-        set_cancelable = env.get_method_id(env.get_object_class(@dialog_ptr), "setCancelable", "(Z)Landroid/app/AlertDialog$Builder;")
-        env.call_object_method(@dialog_ptr, set_cancelable, value)
+        JNIHelpers.call_object(env, @dialog_ptr, "setCancelable", "(Z)Landroid/app/AlertDialog$Builder;", , value)
       {% end %}
     end
 
@@ -132,8 +134,7 @@ module Native::Dialog
         return unless env && @dialog_ptr != 0
         create = env.get_method_id(env.get_object_class(@dialog_ptr), "create", "()Landroid/app/AlertDialog;")
         dialog = env.call_object_method(@dialog_ptr, create)
-        show_method = env.get_method_id(env.get_object_class(dialog), "show", "()V")
-        env.call_void_method(dialog, show_method)
+        JNIHelpers.call_void(env, dialog, "show", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.alert_show(@dialog_ptr)
       {% end %}
@@ -145,8 +146,7 @@ module Native::Dialog
         return unless env && @dialog_ptr != 0
         create = env.get_method_id(env.get_object_class(@dialog_ptr), "create", "()Landroid/app/AlertDialog;")
         dialog = env.call_object_method(@dialog_ptr, create)
-        dismiss_method = env.get_method_id(env.get_object_class(dialog), "dismiss", "()V")
-        env.call_void_method(dialog, dismiss_method)
+        JNIHelpers.call_void(env, dialog, "dismiss", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.alert_dismiss(@dialog_ptr)
       {% end %}

--- a/src/native/framework/dialog/alert_dialog.cr
+++ b/src/native/framework/dialog/alert_dialog.cr
@@ -35,7 +35,7 @@ module Native::Dialog
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @dialog_ptr != 0
-        JNIHelpers.call_object(env, @dialog_ptr, "setTitle", "(Ljava/lang/CharSequence;)Landroid/app/AlertDialog$Builder;", , env.new_string_utf(value))
+        JNIHelpers.call_object_string(env, @dialog_ptr, "setTitle", "(Ljava/lang/CharSequence;)Landroid/app/AlertDialog$Builder;", value)
       {% elsif flag?(:native_ios) %}
         LibIOS.alert_set_title(@dialog_ptr, value.to_utf8)
       {% end %}
@@ -50,7 +50,7 @@ module Native::Dialog
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @dialog_ptr != 0
-        JNIHelpers.call_object(env, @dialog_ptr, "setMessage", "(Ljava/lang/CharSequence;)Landroid/app/AlertDialog$Builder;", , env.new_string_utf(value))
+        JNIHelpers.call_object_string(env, @dialog_ptr, "setMessage", "(Ljava/lang/CharSequence;)Landroid/app/AlertDialog$Builder;", value)
       {% elsif flag?(:native_ios) %}
         LibIOS.alert_set_message(@dialog_ptr, value.to_utf8)
       {% end %}
@@ -108,7 +108,7 @@ module Native::Dialog
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @dialog_ptr != 0
-        JNIHelpers.call_object(env, @dialog_ptr, "setCancelable", "(Z)Landroid/app/AlertDialog$Builder;", , value)
+        JNIHelpers.call_object(env, @dialog_ptr, "setCancelable", "(Z)Landroid/app/AlertDialog$Builder;", value)
       {% end %}
     end
 

--- a/src/native/framework/dialog/toast.cr
+++ b/src/native/framework/dialog/toast.cr
@@ -1,4 +1,5 @@
 # src/native/framework/dialog/toast.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Dialog
   class Toast
@@ -42,6 +43,7 @@ module Native::Dialog
         toast = env.call_static_object_method(toast_class, make_text, activity, env.new_string_utf(@text), @duration.value)
 
         show_method = env.get_method_id(toast_class, "show", "()V")
+        env.delete_local_ref(toast_class) unless toast_class.null?
         env.call_void_method(toast, show_method)
       {% elsif flag?(:native_ios) %}
         LibIOS.show_toast(@text.to_utf8, @duration == Length::Long ? 3.5 : 2.0)

--- a/src/native/framework/image_picker.cr
+++ b/src/native/framework/image_picker.cr
@@ -1,4 +1,5 @@
 # src/native/framework/image_picker.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::ImagePicker
   enum ImageSource
@@ -45,18 +46,20 @@ module Native::ImagePicker
       @@callback = callback
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return unless activity
 
-        picker_class = env.find_class("com/nativecr/ImagePickerHelper")
-        if picker_class == Pointer(Void).null
-          callback.call(ImagePickerResult.new(success: false, error_message: "ImagePicker class not found"))
-          return
+          JNIHelpers.with_class(env, "com/nativecr/ImagePickerHelper") do |picker_class|
+            if picker_class.null?
+              callback.call(ImagePickerResult.new(success: false, error_message: "ImagePicker class not found"))
+              next
+            end
+            pick_method = env.get_static_method_id(picker_class, "pickImage", "(Landroid/app/Activity;III)V")
+            next if pick_method.null?
+            env.call_static_void_method(picker_class, pick_method, activity, source.value, quality.value, 0)
+          end
         end
-
-        pick_method = env.get_static_method_id(picker_class, "pickImage", "(Landroid/app/Activity;III)V")
-        env.call_static_void_method(picker_class, pick_method, activity, source.value, quality.value, 0)
       {% elsif flag?(:native_ios) %}
         LibIOS.image_picker_pick(source.value, quality.value, max_width, max_height)
       {% else %}
@@ -71,18 +74,20 @@ module Native::ImagePicker
       @@callback = callback
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return unless activity
 
-        picker_class = env.find_class("com/nativecr/ImagePickerHelper")
-        if picker_class == Pointer(Void).null
-          callback.call(ImagePickerResult.new(success: false, error_message: "ImagePicker class not found"))
-          return
+          JNIHelpers.with_class(env, "com/nativecr/ImagePickerHelper") do |picker_class|
+            if picker_class.null?
+              callback.call(ImagePickerResult.new(success: false, error_message: "ImagePicker class not found"))
+              next
+            end
+            take_method = env.get_static_method_id(picker_class, "takePhoto", "(Landroid/app/Activity;III)V")
+            next if take_method.null?
+            env.call_static_void_method(picker_class, take_method, activity, quality.value, 0)
+          end
         end
-
-        take_method = env.get_static_method_id(picker_class, "takePhoto", "(Landroid/app/Activity;III)V")
-        env.call_static_void_method(picker_class, take_method, activity, quality.value, 0)
       {% elsif flag?(:native_ios) %}
         LibIOS.image_picker_take_photo(quality.value, max_width, max_height)
       {% else %}

--- a/src/native/framework/location.cr
+++ b/src/native/framework/location.cr
@@ -1,4 +1,5 @@
 # src/native/framework/location.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Location
   enum LocationAccuracy
@@ -66,6 +67,7 @@ module Native::Location
 
         init_method = env.get_static_method_id(location_class, "init", "(Landroid/app/Activity;)V")
         env.call_static_void_method(location_class, init_method, activity)
+        env.delete_local_ref(location_class) unless location_class.null?
 
         setupCallbacks
       {% end %}
@@ -89,6 +91,7 @@ module Native::Location
 
         start_method = env.get_static_method_id(location_class, "startUpdates", "(IIFJ)V")
         env.call_static_void_method(location_class, start_method, accuracy.value, 0, min_distance, min_time)
+        env.delete_local_ref(location_class) unless location_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.location_start_updates(accuracy.value, min_distance, min_time)
       {% end %}
@@ -108,6 +111,7 @@ module Native::Location
 
         stop_method = env.get_static_method_id(location_class, "stopUpdates", "()V")
         env.call_static_void_method(location_class, stop_method)
+        env.delete_local_ref(location_class) unless location_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.location_stop_updates
       {% end %}
@@ -129,6 +133,7 @@ module Native::Location
 
         get_method = env.get_static_method_id(location_class, "getLastLocation", "()Ljava/lang/String;")
         result = env.call_static_object_method(location_class, get_method)
+        env.delete_local_ref(location_class) unless location_class.null?
 
         if result
           json = env.get_string_utf_chars(result, nil).to_s
@@ -167,21 +172,16 @@ module Native::Location
       {% unless flag?(:native_android) %}
         return
       {% end %}
-      env = Native::Android::JNI.env
-      return unless env
+      JNIHelpers.with_env do |env|
+        callback_obj = JNIHelpers.new_callback(env, "com/nativecr/LocationCallback", 0i64)
+        return if callback_obj.null?
 
-      callback_class = env.find_class("com/nativecr/LocationCallback")
-      if callback_class == Pointer(Void).null
-        return
+        begin
+          JNIHelpers.call_static_void(env, "com/nativecr/LocationHelper", "setCallback", "(Lcom/nativecr/LocationCallback;)V", callback_obj)
+        ensure
+          env.delete_local_ref(callback_obj)
+        end
       end
-
-      callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
-
-      location_class = env.find_class("com/nativecr/LocationHelper")
-      return if location_class == Pointer(Void).null
-
-      set_callback = env.get_static_method_id(location_class, "setCallback", "(Lcom/nativecr/LocationCallback;)V")
-      env.call_static_void_method(location_class, set_callback, callback_obj)
     end
 
     private def parse_location_json(json : String) : Location?

--- a/src/native/framework/media/audio.cr
+++ b/src/native/framework/media/audio.cr
@@ -1,4 +1,5 @@
 # src/native/framework/audio.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Audio
   enum AudioFormat
@@ -44,6 +45,7 @@ module Native::Audio
         end
 
         @sound_ptr = env.call_static_long_method(sound_class, load_method, activity, env.new_string_utf(path))
+        env.delete_local_ref(sound_class) unless sound_class.null?
         @is_loaded = @sound_ptr != 0
         @is_loaded
       {% elsif flag?(:native_ios) %}
@@ -74,6 +76,7 @@ module Native::Audio
         end
 
         instance_ptr = env.call_static_long_method(sound_class, play_method, @sound_ptr, config.volume, config.loop ? 1 : 0, config.pitch, config.pan)
+        env.delete_local_ref(sound_class) unless sound_class.null?
         if instance_ptr != 0
           SoundInstance.new(instance_ptr)
         else
@@ -103,6 +106,7 @@ module Native::Audio
           stop_method = env.get_static_method_id(sound_class, "stopAll", "(J)V")
           if stop_method != Pointer(Void).null
             env.call_static_void_method(sound_class, stop_method, @sound_ptr)
+            env.delete_local_ref(sound_class) unless sound_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -130,6 +134,7 @@ module Native::Audio
           unload_method = env.get_static_method_id(sound_class, "unload", "(J)V")
           if unload_method != Pointer(Void).null
             env.call_static_void_method(sound_class, unload_method, @sound_ptr)
+            env.delete_local_ref(sound_class) unless sound_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -160,6 +165,7 @@ module Native::Audio
           stop_method = env.get_static_method_id(sound_class, "stopInstance", "(J)V")
           if stop_method != Pointer(Void).null
             env.call_static_void_method(sound_class, stop_method, @instance_ptr)
+            env.delete_local_ref(sound_class) unless sound_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -181,6 +187,7 @@ module Native::Audio
           pause_method = env.get_static_method_id(sound_class, "pause", "(J)V")
           if pause_method != Pointer(Void).null
             env.call_static_void_method(sound_class, pause_method, @instance_ptr)
+            env.delete_local_ref(sound_class) unless sound_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -198,6 +205,7 @@ module Native::Audio
           resume_method = env.get_static_method_id(sound_class, "resume", "(J)V")
           if resume_method != Pointer(Void).null
             env.call_static_void_method(sound_class, resume_method, @instance_ptr)
+            env.delete_local_ref(sound_class) unless sound_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -217,6 +225,7 @@ module Native::Audio
           volume_method = env.get_static_method_id(sound_class, "setVolume", "(JF)V")
           if volume_method != Pointer(Void).null
             env.call_static_void_method(sound_class, volume_method, @instance_ptr, value)
+            env.delete_local_ref(sound_class) unless sound_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -235,7 +244,9 @@ module Native::Audio
         if sound_class != Pointer(Void).null
           playing_method = env.get_static_method_id(sound_class, "isPlaying", "(J)Z")
           if playing_method != Pointer(Void).null
-            return env.call_static_boolean_method(sound_class, playing_method, @instance_ptr)
+            _jni_res = env.call_static_boolean_method(sound_class, playing_method, @instance_ptr)
+            env.delete_local_ref(sound_class) unless sound_class.null?
+            return _jni_res
           end
         end
         false
@@ -273,6 +284,7 @@ module Native::Audio
         end
 
         @music_ptr = env.call_static_long_method(music_class, load_method, activity, env.new_string_utf(path))
+        env.delete_local_ref(music_class) unless music_class.null?
         @music_ptr != 0
       {% elsif flag?(:native_ios) %}
         ptr = LibIOS.music_load(path.to_utf8)
@@ -295,6 +307,7 @@ module Native::Audio
           play_method = env.get_static_method_id(music_class, "play", "(JZ)V")
           if play_method != Pointer(Void).null
             env.call_static_void_method(music_class, play_method, @music_ptr, loop)
+            env.delete_local_ref(music_class) unless music_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -316,6 +329,7 @@ module Native::Audio
           pause_method = env.get_static_method_id(music_class, "pause", "(J)V")
           if pause_method != Pointer(Void).null
             env.call_static_void_method(music_class, pause_method, @music_ptr)
+            env.delete_local_ref(music_class) unless music_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -337,6 +351,7 @@ module Native::Audio
           resume_method = env.get_static_method_id(music_class, "resume", "(J)V")
           if resume_method != Pointer(Void).null
             env.call_static_void_method(music_class, resume_method, @music_ptr)
+            env.delete_local_ref(music_class) unless music_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -358,6 +373,7 @@ module Native::Audio
           stop_method = env.get_static_method_id(music_class, "stop", "(J)V")
           if stop_method != Pointer(Void).null
             env.call_static_void_method(music_class, stop_method, @music_ptr)
+            env.delete_local_ref(music_class) unless music_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -379,6 +395,7 @@ module Native::Audio
           volume_method = env.get_static_method_id(music_class, "setVolume", "(JF)V")
           if volume_method != Pointer(Void).null
             env.call_static_void_method(music_class, volume_method, @music_ptr, @volume)
+            env.delete_local_ref(music_class) unless music_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -406,6 +423,7 @@ module Native::Audio
           seek_method = env.get_static_method_id(music_class, "seek", "(JD)V")
           if seek_method != Pointer(Void).null
             env.call_static_void_method(music_class, seek_method, @music_ptr, position)
+            env.delete_local_ref(music_class) unless music_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -424,7 +442,9 @@ module Native::Audio
         if music_class != Pointer(Void).null
           position_method = env.get_static_method_id(music_class, "getPosition", "(J)D")
           if position_method != Pointer(Void).null
-            return env.call_static_double_method(music_class, position_method, @music_ptr)
+            _jni_res = env.call_static_double_method(music_class, position_method, @music_ptr)
+            env.delete_local_ref(music_class) unless music_class.null?
+            return _jni_res
           end
         end
         0.0
@@ -446,7 +466,9 @@ module Native::Audio
         if music_class != Pointer(Void).null
           duration_method = env.get_static_method_id(music_class, "getDuration", "(J)D")
           if duration_method != Pointer(Void).null
-            return env.call_static_double_method(music_class, duration_method, @music_ptr)
+            _jni_res = env.call_static_double_method(music_class, duration_method, @music_ptr)
+            env.delete_local_ref(music_class) unless music_class.null?
+            return _jni_res
           end
         end
         0.0
@@ -469,6 +491,7 @@ module Native::Audio
           unload_method = env.get_static_method_id(music_class, "unload", "(J)V")
           if unload_method != Pointer(Void).null
             env.call_static_void_method(music_class, unload_method, @music_ptr)
+            env.delete_local_ref(music_class) unless music_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -505,6 +528,7 @@ module Native::Audio
         end
 
         @recorder_ptr = env.call_static_long_method(recorder_class, start_method, activity)
+        env.delete_local_ref(recorder_class) unless recorder_class.null?
         @is_recording = @recorder_ptr != 0
         @is_recording
       {% elsif flag?(:native_ios) %}
@@ -535,6 +559,7 @@ module Native::Audio
         end
 
         byte_array = env.call_static_object_method(recorder_class, stop_method, @recorder_ptr)
+        env.delete_local_ref(recorder_class) unless recorder_class.null?
         @is_recording = false
         @recorder_ptr = 0
 
@@ -612,6 +637,7 @@ module Native::Audio
           set_volume_method = env.get_static_method_id(audio_class, "setMasterVolume", "(F)V")
           if set_volume_method != Pointer(Void).null
             env.call_static_void_method(audio_class, set_volume_method, @master_volume)
+            env.delete_local_ref(audio_class) unless audio_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -644,6 +670,7 @@ module Native::Audio
           stop_method = env.get_static_method_id(audio_class, "stopAll", "()V")
           if stop_method != Pointer(Void).null
             env.call_static_void_method(audio_class, stop_method)
+            env.delete_local_ref(audio_class) unless audio_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -662,6 +689,7 @@ module Native::Audio
           pause_method = env.get_static_method_id(audio_class, "pauseAll", "()V")
           if pause_method != Pointer(Void).null
             env.call_static_void_method(audio_class, pause_method)
+            env.delete_local_ref(audio_class) unless audio_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}
@@ -680,6 +708,7 @@ module Native::Audio
           resume_method = env.get_static_method_id(audio_class, "resumeAll", "()V")
           if resume_method != Pointer(Void).null
             env.call_static_void_method(audio_class, resume_method)
+            env.delete_local_ref(audio_class) unless audio_class.null?
           end
         end
       {% elsif flag?(:native_ios) %}

--- a/src/native/framework/media/camera.cr
+++ b/src/native/framework/media/camera.cr
@@ -161,15 +161,14 @@ module Native::Media
       env = Native::Android::JNI.env
       return unless env && @camera_ptr != 0
 
-      callback_class = env.find_class("com/nativecr/CameraCallback")
-      if callback_class == Pointer(Void).null
-        return
+      callback_obj = JNIHelpers.new_callback(env, "com/nativecr/CameraCallback", 0i64)
+      return if callback_obj.null?
+
+      begin
+        JNIHelpers.call_void(env, @camera_ptr, "setCallback", "(Lcom/nativecr/CameraCallback;)V", callback_obj)
+      ensure
+        env.delete_local_ref(callback_obj)
       end
-
-      callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
-      env.delete_local_ref(callback_class) unless callback_class.null?
-
-      JNIHelpers.call_void(env, @camera_ptr, "setCallback", "(Lcom/nativecr/CameraCallback;)V", callback_obj)
     end
 
     def handlePhotoCaptured(data : Bytes, width : Int32, height : Int32)

--- a/src/native/framework/media/camera.cr
+++ b/src/native/framework/media/camera.cr
@@ -55,7 +55,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @camera_ptr != 0
-        JNIHelpers.call_void(env, @camera_ptr, "setFacing", "(I)V", , value.value)
+        JNIHelpers.call_void(env, @camera_ptr, "setFacing", "(I)V", value.value)
       {% elsif flag?(:native_ios) %}
         LibIOS.camera_set_facing(@camera_ptr, value.value)
       {% end %}
@@ -70,7 +70,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @camera_ptr != 0
-        JNIHelpers.call_void(env, @camera_ptr, "setFlashMode", "(I)V", , value.value)
+        JNIHelpers.call_void(env, @camera_ptr, "setFlashMode", "(I)V", value.value)
       {% elsif flag?(:native_ios) %}
         LibIOS.camera_set_flash_mode(@camera_ptr, value.value)
       {% end %}
@@ -122,7 +122,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @camera_ptr != 0
-        JNIHelpers.call_void(env, @camera_ptr, "startRecording", "(Ljava/lang/String;)V", , env.new_string_utf(output_path))
+        JNIHelpers.call_void_string(env, @camera_ptr, "startRecording", "(Ljava/lang/String;)V", output_path)
       {% elsif flag?(:native_ios) %}
         LibIOS.camera_start_recording(@camera_ptr, output_path.to_utf8)
       {% end %}
@@ -169,7 +169,7 @@ module Native::Media
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
       env.delete_local_ref(callback_class) unless callback_class.null?
 
-      JNIHelpers.call_void(env, @camera_ptr, "setCallback", "(Lcom/nativecr/CameraCallback;)V", , callback_obj)
+      JNIHelpers.call_void(env, @camera_ptr, "setCallback", "(Lcom/nativecr/CameraCallback;)V", callback_obj)
     end
 
     def handlePhotoCaptured(data : Bytes, width : Int32, height : Int32)

--- a/src/native/framework/media/camera.cr
+++ b/src/native/framework/media/camera.cr
@@ -1,4 +1,5 @@
 # src/native/framework/media/camera.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Media
   class Camera
@@ -40,6 +41,7 @@ module Native::Media
 
         constructor = env.get_method_id(camera_class, "<init>", "(Landroid/app/Activity;)V")
         @camera_ptr = env.new_object(camera_class, constructor, activity).to_i64
+        env.delete_local_ref(camera_class) unless camera_class.null?
 
         setupCallbacks
       {% elsif flag?(:native_ios) %}
@@ -53,8 +55,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @camera_ptr != 0
-        set_facing = env.get_method_id(env.get_object_class(@camera_ptr), "setFacing", "(I)V")
-        env.call_void_method(@camera_ptr, set_facing, value.value)
+        JNIHelpers.call_void(env, @camera_ptr, "setFacing", "(I)V", , value.value)
       {% elsif flag?(:native_ios) %}
         LibIOS.camera_set_facing(@camera_ptr, value.value)
       {% end %}
@@ -69,8 +70,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @camera_ptr != 0
-        set_flash = env.get_method_id(env.get_object_class(@camera_ptr), "setFlashMode", "(I)V")
-        env.call_void_method(@camera_ptr, set_flash, value.value)
+        JNIHelpers.call_void(env, @camera_ptr, "setFlashMode", "(I)V", , value.value)
       {% elsif flag?(:native_ios) %}
         LibIOS.camera_set_flash_mode(@camera_ptr, value.value)
       {% end %}
@@ -92,8 +92,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @camera_ptr != 0 && view.native_ptr != 0
-        start_preview = env.get_method_id(env.get_object_class(@camera_ptr), "startPreview", "(Landroid/view/View;)V")
-        env.call_void_method(@camera_ptr, start_preview, view.native_ptr)
+        JNIHelpers.call_void(env, @camera_ptr, "startPreview", "(Landroid/view/View;)V", view.native_ptr)
       {% elsif flag?(:native_ios) %}
         LibIOS.camera_start_preview(@camera_ptr, view.native_ptr)
       {% end %}
@@ -103,8 +102,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @camera_ptr != 0
-        stop_preview = env.get_method_id(env.get_object_class(@camera_ptr), "stopPreview", "()V")
-        env.call_void_method(@camera_ptr, stop_preview)
+        JNIHelpers.call_void(env, @camera_ptr, "stopPreview", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.camera_stop_preview(@camera_ptr)
       {% end %}
@@ -114,8 +112,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @camera_ptr != 0
-        take_photo = env.get_method_id(env.get_object_class(@camera_ptr), "takePhoto", "()V")
-        env.call_void_method(@camera_ptr, take_photo)
+        JNIHelpers.call_void(env, @camera_ptr, "takePhoto", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.camera_take_photo(@camera_ptr)
       {% end %}
@@ -125,8 +122,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @camera_ptr != 0
-        start_rec = env.get_method_id(env.get_object_class(@camera_ptr), "startRecording", "(Ljava/lang/String;)V")
-        env.call_void_method(@camera_ptr, start_rec, env.new_string_utf(output_path))
+        JNIHelpers.call_void(env, @camera_ptr, "startRecording", "(Ljava/lang/String;)V", , env.new_string_utf(output_path))
       {% elsif flag?(:native_ios) %}
         LibIOS.camera_start_recording(@camera_ptr, output_path.to_utf8)
       {% end %}
@@ -136,8 +132,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @camera_ptr != 0
-        stop_rec = env.get_method_id(env.get_object_class(@camera_ptr), "stopRecording", "()V")
-        env.call_void_method(@camera_ptr, stop_rec)
+        JNIHelpers.call_void(env, @camera_ptr, "stopRecording", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.camera_stop_recording(@camera_ptr)
       {% end %}
@@ -172,9 +167,9 @@ module Native::Media
       end
 
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
+      env.delete_local_ref(callback_class) unless callback_class.null?
 
-      set_callback = env.get_method_id(env.get_object_class(@camera_ptr), "setCallback", "(Lcom/nativecr/CameraCallback;)V")
-      env.call_void_method(@camera_ptr, set_callback, callback_obj)
+      JNIHelpers.call_void(env, @camera_ptr, "setCallback", "(Lcom/nativecr/CameraCallback;)V", , callback_obj)
     end
 
     def handlePhotoCaptured(data : Bytes, width : Int32, height : Int32)

--- a/src/native/framework/media/video.cr
+++ b/src/native/framework/media/video.cr
@@ -48,7 +48,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "loadVideo", "(Ljava/lang/String;)V", , env.new_string_utf(path))
+        JNIHelpers.call_void_string(env, @native, "loadVideo", "(Ljava/lang/String;)V", path)
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_load(@native, path.to_utf8)
       {% end %}
@@ -99,7 +99,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setLooping", "(Z)V", , value)
+        JNIHelpers.call_void(env, @native, "setLooping", "(Z)V", value)
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_set_looping(@native, value)
       {% end %}
@@ -114,7 +114,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setVolume", "(FF)V", , @volume, @volume)
+        JNIHelpers.call_void(env, @native, "setVolume", "(FF)V", @volume, @volume)
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_set_volume(@native, @volume)
       {% end %}
@@ -134,7 +134,7 @@ module Native::Media
                       when ScaleType::FitCenter  then 1
                       when ScaleType::CenterCrop then 2
                       end
-        JNIHelpers.call_void(env, @native, "setScaleType", "(I)V", , scale_value)
+        JNIHelpers.call_void(env, @native, "setScaleType", "(I)V", scale_value)
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_set_scale_type(@native, value.value)
       {% end %}
@@ -148,7 +148,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "seekTo", "(I)V", , msec)
+        JNIHelpers.call_void(env, @native, "seekTo", "(I)V", msec)
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_seek_to(@native, msec)
       {% end %}
@@ -209,7 +209,7 @@ module Native::Media
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
       env.delete_local_ref(callback_class) unless callback_class.null?
 
-      JNIHelpers.call_void(env, @native, "setCallback", "(Lcom/nativecr/VideoPlayerCallback;)V", , callback_obj)
+      JNIHelpers.call_void(env, @native, "setCallback", "(Lcom/nativecr/VideoPlayerCallback;)V", callback_obj)
     end
 
     def handlePrepared

--- a/src/native/framework/media/video.cr
+++ b/src/native/framework/media/video.cr
@@ -201,15 +201,14 @@ module Native::Media
       env = Native::Android::JNI.env
       return unless env && @native != 0
 
-      callback_class = env.find_class("com/nativecr/VideoPlayerCallback")
-      if callback_class == Pointer(Void).null
-        return
+      callback_obj = JNIHelpers.new_callback(env, "com/nativecr/VideoPlayerCallback", 0i64)
+      return if callback_obj.null?
+
+      begin
+        JNIHelpers.call_void(env, @native, "setCallback", "(Lcom/nativecr/VideoPlayerCallback;)V", callback_obj)
+      ensure
+        env.delete_local_ref(callback_obj)
       end
-
-      callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
-      env.delete_local_ref(callback_class) unless callback_class.null?
-
-      JNIHelpers.call_void(env, @native, "setCallback", "(Lcom/nativecr/VideoPlayerCallback;)V", callback_obj)
     end
 
     def handlePrepared

--- a/src/native/framework/media/video.cr
+++ b/src/native/framework/media/video.cr
@@ -1,4 +1,5 @@
 # src/native/framework/media/video.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Media
   class VideoPlayer < UI::View
@@ -33,6 +34,7 @@ module Native::Media
 
         constructor = env.get_method_id(video_class, "<init>", "(Landroid/app/Activity;)V")
         @native = env.new_object(video_class, constructor, activity).to_i64
+        env.delete_local_ref(video_class) unless video_class.null?
 
         setupCallbacks
       {% elsif flag?(:native_ios) %}
@@ -46,8 +48,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        load_video = env.get_method_id(env.get_object_class(@native), "loadVideo", "(Ljava/lang/String;)V")
-        env.call_void_method(@native, load_video, env.new_string_utf(path))
+        JNIHelpers.call_void(env, @native, "loadVideo", "(Ljava/lang/String;)V", , env.new_string_utf(path))
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_load(@native, path.to_utf8)
       {% end %}
@@ -57,8 +58,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        play_video = env.get_method_id(env.get_object_class(@native), "play", "()V")
-        env.call_void_method(@native, play_video)
+        JNIHelpers.call_void(env, @native, "play", "()V")
         @is_playing = true
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_play(@native)
@@ -70,8 +70,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        pause_video = env.get_method_id(env.get_object_class(@native), "pause", "()V")
-        env.call_void_method(@native, pause_video)
+        JNIHelpers.call_void(env, @native, "pause", "()V")
         @is_playing = false
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_pause(@native)
@@ -83,8 +82,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        stop_video = env.get_method_id(env.get_object_class(@native), "stop", "()V")
-        env.call_void_method(@native, stop_video)
+        JNIHelpers.call_void(env, @native, "stop", "()V")
         @is_playing = false
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_stop(@native)
@@ -101,8 +99,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_loop = env.get_method_id(env.get_object_class(@native), "setLooping", "(Z)V")
-        env.call_void_method(@native, set_loop, value)
+        JNIHelpers.call_void(env, @native, "setLooping", "(Z)V", , value)
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_set_looping(@native, value)
       {% end %}
@@ -117,8 +114,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_volume = env.get_method_id(env.get_object_class(@native), "setVolume", "(FF)V")
-        env.call_void_method(@native, set_volume, @volume, @volume)
+        JNIHelpers.call_void(env, @native, "setVolume", "(FF)V", , @volume, @volume)
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_set_volume(@native, @volume)
       {% end %}
@@ -138,8 +134,7 @@ module Native::Media
                       when ScaleType::FitCenter  then 1
                       when ScaleType::CenterCrop then 2
                       end
-        set_scale = env.get_method_id(env.get_object_class(@native), "setScaleType", "(I)V")
-        env.call_void_method(@native, set_scale, scale_value)
+        JNIHelpers.call_void(env, @native, "setScaleType", "(I)V", , scale_value)
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_set_scale_type(@native, value.value)
       {% end %}
@@ -153,8 +148,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        seek = env.get_method_id(env.get_object_class(@native), "seekTo", "(I)V")
-        env.call_void_method(@native, seek, msec)
+        JNIHelpers.call_void(env, @native, "seekTo", "(I)V", , msec)
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_seek_to(@native, msec)
       {% end %}
@@ -164,8 +158,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return 0 unless env && @native != 0
-        get_pos = env.get_method_id(env.get_object_class(@native), "getCurrentPosition", "()I")
-        env.call_int_method(@native, get_pos)
+        JNIHelpers.call_int(env, @native, "getCurrentPosition", "()I")
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_current_position(@native)
       {% else %}
@@ -177,8 +170,7 @@ module Native::Media
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return 0 unless env && @native != 0
-        get_dur = env.get_method_id(env.get_object_class(@native), "getDuration", "()I")
-        env.call_int_method(@native, get_dur)
+        JNIHelpers.call_int(env, @native, "getDuration", "()I")
       {% elsif flag?(:native_ios) %}
         LibIOS.video_player_duration(@native)
       {% else %}
@@ -215,9 +207,9 @@ module Native::Media
       end
 
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
+      env.delete_local_ref(callback_class) unless callback_class.null?
 
-      set_callback = env.get_method_id(env.get_object_class(@native), "setCallback", "(Lcom/nativecr/VideoPlayerCallback;)V")
-      env.call_void_method(@native, set_callback, callback_obj)
+      JNIHelpers.call_void(env, @native, "setCallback", "(Lcom/nativecr/VideoPlayerCallback;)V", , callback_obj)
     end
 
     def handlePrepared

--- a/src/native/framework/navigation/toolbar.cr
+++ b/src/native/framework/navigation/toolbar.cr
@@ -45,7 +45,7 @@ module Native::Navigation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setTitle", "(Ljava/lang/CharSequence;)V", , env.new_string_utf(value))
+        JNIHelpers.call_void_string(env, @native, "setTitle", "(Ljava/lang/CharSequence;)V", value)
       {% elsif flag?(:native_ios) %}
         LibIOS.navigation_bar_set_title(@native, value.to_utf8)
       {% end %}
@@ -60,7 +60,7 @@ module Native::Navigation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setSubtitle", "(Ljava/lang/CharSequence;)V", , env.new_string_utf(value))
+        JNIHelpers.call_void_string(env, @native, "setSubtitle", "(Ljava/lang/CharSequence;)V", value)
       {% end %}
     end
 
@@ -101,9 +101,9 @@ module Native::Navigation
         menu_item = env.call_object_method(menu, add_item, 0, id, 0, env.new_string_utf(title))
 
         if icon != 0 && show_as_action
-          JNIHelpers.call_object(env, menu_item, "setIcon", "(I)Landroid/view/MenuItem;", , icon)
+          JNIHelpers.call_object(env, menu_item, "setIcon", "(I)Landroid/view/MenuItem;", icon)
 
-          JNIHelpers.call_void(env, menu_item, "setShowAsAction", "(I)V", , 2)
+          JNIHelpers.call_void(env, menu_item, "setShowAsAction", "(I)V", 2)
         end
       {% end %}
     end
@@ -118,7 +118,7 @@ module Native::Navigation
         activity = Native::Android::JNI.activity
         return unless env && activity
 
-        JNIHelpers.call_void(env, activity, "setSupportActionBar", "(Landroidx/appcompat/widget/Toolbar;)V", , @native)
+        JNIHelpers.call_void(env, activity, "setSupportActionBar", "(Landroidx/appcompat/widget/Toolbar;)V", @native)
       {% end %}
     end
 

--- a/src/native/framework/navigation/toolbar.cr
+++ b/src/native/framework/navigation/toolbar.cr
@@ -98,13 +98,17 @@ module Native::Navigation
         menu = env.call_object_method(@native, add_method)
 
         add_item = env.get_method_id(env.get_object_class(menu), "add", "(IIII)Landroid/view/MenuItem;")
-        menu_item = env.call_object_method(menu, add_item, 0, id, 0, env.new_string_utf(title))
+        JNIHelpers.with_jstring(env, title) do |jtitle|
+          menu_item = env.call_object_method(menu, add_item, 0, id, 0, jtitle)
 
-        if icon != 0 && show_as_action
-          JNIHelpers.call_object(env, menu_item, "setIcon", "(I)Landroid/view/MenuItem;", icon)
+          if icon != 0 && show_as_action
+            JNIHelpers.call_object(env, menu_item, "setIcon", "(I)Landroid/view/MenuItem;", icon)
 
-          JNIHelpers.call_void(env, menu_item, "setShowAsAction", "(I)V", 2)
+            JNIHelpers.call_void(env, menu_item, "setShowAsAction", "(I)V", 2)
+          end
+          env.delete_local_ref(menu_item) unless menu_item.null?
         end
+        env.delete_local_ref(menu_class) unless menu_class.null?
       {% end %}
     end
 

--- a/src/native/framework/navigation/toolbar.cr
+++ b/src/native/framework/navigation/toolbar.cr
@@ -1,4 +1,5 @@
 # src/native/framework/navigation/toolbar.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Navigation
   class Toolbar < UI::View
@@ -30,6 +31,7 @@ module Native::Navigation
         toolbar_class = env.find_class("androidx/appcompat/widget/Toolbar")
         constructor = env.get_method_id(toolbar_class, "<init>", "(Landroid/content/Context;)V")
         @native = env.new_object(toolbar_class, constructor, activity).to_i64
+        env.delete_local_ref(toolbar_class) unless toolbar_class.null?
 
         setupNavigation
       {% elsif flag?(:native_ios) %}
@@ -43,8 +45,7 @@ module Native::Navigation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_title = env.get_method_id(env.get_object_class(@native), "setTitle", "(Ljava/lang/CharSequence;)V")
-        env.call_void_method(@native, set_title, env.new_string_utf(value))
+        JNIHelpers.call_void(env, @native, "setTitle", "(Ljava/lang/CharSequence;)V", , env.new_string_utf(value))
       {% elsif flag?(:native_ios) %}
         LibIOS.navigation_bar_set_title(@native, value.to_utf8)
       {% end %}
@@ -59,8 +60,7 @@ module Native::Navigation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_subtitle = env.get_method_id(env.get_object_class(@native), "setSubtitle", "(Ljava/lang/CharSequence;)V")
-        env.call_void_method(@native, set_subtitle, env.new_string_utf(value))
+        JNIHelpers.call_void(env, @native, "setSubtitle", "(Ljava/lang/CharSequence;)V", , env.new_string_utf(value))
       {% end %}
     end
 
@@ -73,8 +73,7 @@ module Native::Navigation
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_nav = env.get_method_id(env.get_object_class(@native), "setNavigationIcon", "(I)V")
-        env.call_void_method(@native, set_nav, resource_id)
+        JNIHelpers.call_void(env, @native, "setNavigationIcon", "(I)V", resource_id)
       {% end %}
     end
 
@@ -102,11 +101,9 @@ module Native::Navigation
         menu_item = env.call_object_method(menu, add_item, 0, id, 0, env.new_string_utf(title))
 
         if icon != 0 && show_as_action
-          set_icon = env.get_method_id(env.get_object_class(menu_item), "setIcon", "(I)Landroid/view/MenuItem;")
-          env.call_object_method(menu_item, set_icon, icon)
+          JNIHelpers.call_object(env, menu_item, "setIcon", "(I)Landroid/view/MenuItem;", , icon)
 
-          set_show = env.get_method_id(env.get_object_class(menu_item), "setShowAsAction", "(I)V")
-          env.call_void_method(menu_item, set_show, 2)
+          JNIHelpers.call_void(env, menu_item, "setShowAsAction", "(I)V", , 2)
         end
       {% end %}
     end
@@ -121,8 +118,7 @@ module Native::Navigation
         activity = Native::Android::JNI.activity
         return unless env && activity
 
-        set_actionbar = env.get_method_id(env.get_object_class(activity), "setSupportActionBar", "(Landroidx/appcompat/widget/Toolbar;)V")
-        env.call_void_method(activity, set_actionbar, @native)
+        JNIHelpers.call_void(env, activity, "setSupportActionBar", "(Landroidx/appcompat/widget/Toolbar;)V", , @native)
       {% end %}
     end
 
@@ -139,9 +135,9 @@ module Native::Navigation
       end
 
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
+      env.delete_local_ref(callback_class) unless callback_class.null?
 
-      set_nav = env.get_method_id(env.get_object_class(@native), "setNavigationOnClickListener", "(Landroid/view/View$OnClickListener;)V")
-      env.call_void_method(@native, set_nav, callback_obj)
+      JNIHelpers.call_void(env, @native, "setNavigationOnClickListener", "(Landroid/view/View$OnClickListener;)V", callback_obj)
     end
 
     def handleNavigationClick

--- a/src/native/framework/network.cr
+++ b/src/native/framework/network.cr
@@ -172,8 +172,12 @@ module Native::Network
       end
 
       result = env.call_static_object_method(http_client_class, execute_method, url_string, method_string, headers_keys, headers_values, body_string, request.timeout)
+      env.delete_local_ref(http_client_class) unless http_client_class.null?
 
       cleanup_android(env, url_string, method_string, headers_keys, headers_values, body_string)
+      env.delete_local_ref(url_string) unless url_string.null?
+      env.delete_local_ref(method_string) unless method_string.null?
+      env.delete_local_ref(body_string) unless body_string.null?
 
       if result
         json = env.get_string_utf_chars(result, nil).to_s
@@ -209,6 +213,7 @@ module Native::Network
       end
 
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "()V"))
+      env.delete_local_ref(callback_class) unless callback_class.null?
 
       stream_method = env.get_static_method_id(http_client_class, "executeStream", "(Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;Lcom/nativecr/StreamCallback;D)V")
       if stream_method == Pointer(Void).null
@@ -218,8 +223,11 @@ module Native::Network
       end
 
       env.call_static_void_method(http_client_class, stream_method, url_string, method_string, headers_keys, headers_values, callback_obj, request.timeout)
+      env.delete_local_ref(http_client_class) unless http_client_class.null?
 
       cleanup_android(env, url_string, method_string, headers_keys, headers_values)
+      env.delete_local_ref(url_string) unless url_string.null?
+      env.delete_local_ref(method_string) unless method_string.null?
       env.delete_local_ref(callback_obj)
 
       Response.new(success: true, status_code: 200)
@@ -463,6 +471,7 @@ module Native::Network
       end
 
       env.call_static_long_method(ws_class, connect_method, activity, env.new_string_utf(@url))
+      env.delete_local_ref(ws_class) unless ws_class.null?
     end
 
     private def connect_ios : Void

--- a/src/native/framework/notifications.cr
+++ b/src/native/framework/notifications.cr
@@ -1,4 +1,5 @@
 # src/native/framework/notifications.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Notifications
   enum NotificationPriority
@@ -85,6 +86,7 @@ module Native::Notifications
 
         init_method = env.get_static_method_id(notif_class, "init", "(Landroid/app/Activity;)V")
         env.call_static_void_method(notif_class, init_method, activity)
+        env.delete_local_ref(notif_class) unless notif_class.null?
 
         channels.each do |channel|
           create_channel(channel)
@@ -111,6 +113,7 @@ module Native::Notifications
 
       create_method = env.get_static_method_id(notif_class, "createChannel", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZZZLjava/lang/String;)V")
       env.call_static_void_method(notif_class, create_method,
+      env.delete_local_ref(notif_class) unless notif_class.null?
         env.new_string_utf(channel.id),
         env.new_string_utf(channel.name),
         channel.description ? env.new_string_utf(channel.description.not_nil!) : Pointer(Void).null,
@@ -137,6 +140,7 @@ module Native::Notifications
         show_method = env.get_static_method_id(notif_class, "showNotification", "(ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIZLjava/lang/String;ZILjava/lang/String;ZLjava/lang/String;)V")
 
         env.call_static_void_method(notif_class, show_method,
+        env.delete_local_ref(notif_class) unless notif_class.null?
           notification.id,
           env.new_string_utf(notification.channel_id),
           env.new_string_utf(notification.title),
@@ -178,6 +182,7 @@ module Native::Notifications
 
         timestamp = notification.schedule_time.not_nil!.to_unix * 1000
         env.call_static_void_method(notif_class, schedule_method,
+        env.delete_local_ref(notif_class) unless notif_class.null?
           notification.id,
           timestamp,
           env.new_string_utf(notification.channel_id),
@@ -206,6 +211,7 @@ module Native::Notifications
 
         cancel_method = env.get_static_method_id(notif_class, "cancelNotification", "(I)V")
         env.call_static_void_method(notif_class, cancel_method, id)
+        env.delete_local_ref(notif_class) unless notif_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.cancel_notification(id)
       {% end %}
@@ -221,6 +227,7 @@ module Native::Notifications
 
         cancel_method = env.get_static_method_id(notif_class, "cancelAllNotifications", "()V")
         env.call_static_void_method(notif_class, cancel_method)
+        env.delete_local_ref(notif_class) unless notif_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.cancel_all_notifications
       {% end %}
@@ -236,6 +243,7 @@ module Native::Notifications
 
         badge_method = env.get_static_method_id(notif_class, "setBadgeNumber", "(I)V")
         env.call_static_void_method(notif_class, badge_method, count)
+        env.delete_local_ref(notif_class) unless notif_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.set_badge_number(count)
       {% end %}
@@ -248,8 +256,7 @@ module Native::Notifications
         return false unless env && activity
 
         notif_manager = env.call_object_method(activity, env.get_method_id(env.get_object_class(activity), "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"), env.new_string_utf("notification"))
-        are_notifs_enabled = env.get_method_id(env.get_object_class(notif_manager), "areNotificationsEnabled", "()Z")
-        env.call_boolean_method(notif_manager, are_notifs_enabled)
+        JNIHelpers.call_boolean(env, notif_manager, "areNotificationsEnabled", "()Z")
       {% elsif flag?(:native_ios) %}
         LibIOS.notification_permission_granted
       {% else %}

--- a/src/native/framework/notifications.cr
+++ b/src/native/framework/notifications.cr
@@ -1,5 +1,9 @@
 # src/native/framework/notifications.cr
 # Refactored to use JNIHelpers for automatic local reference cleanup.
+# Also fixed: delete_local_ref statements that had been inserted in the
+# middle of argument lists (parse errors), and raw Crystal strings
+# (payload.to_json, joined action ids) passed where the JNI signature
+# wants jstrings — jvalues would have silently passed NULL.
 
 module Native::Notifications
   enum NotificationPriority
@@ -75,21 +79,15 @@ module Native::Notifications
       return if @@initialized
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          next unless activity
 
-        notif_class = env.find_class("com/nativecr/NotificationHelper")
-        if notif_class == Pointer(Void).null
-          return
-        end
+          JNIHelpers.call_static_void(env, "com/nativecr/NotificationHelper", "init", "(Landroid/app/Activity;)V", activity)
 
-        init_method = env.get_static_method_id(notif_class, "init", "(Landroid/app/Activity;)V")
-        env.call_static_void_method(notif_class, init_method, activity)
-        env.delete_local_ref(notif_class) unless notif_class.null?
-
-        channels.each do |channel|
-          create_channel(channel)
+          channels.each do |channel|
+            create_channel(channel)
+          end
         end
       {% elsif flag?(:native_ios) %}
         LibIOS.notification_init
@@ -103,94 +101,112 @@ module Native::Notifications
         return
       {% end %}
 
-      env = Native::Android::JNI.env
-      return unless env
+      JNIHelpers.with_env do |env|
+        JNIHelpers.with_class(env, "com/nativecr/NotificationHelper") do |notif_class|
+          next if notif_class.null?
+          create_method = env.get_static_method_id(notif_class, "createChannel", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZZZLjava/lang/String;)V")
+          next if create_method.null?
 
-      notif_class = env.find_class("com/nativecr/NotificationHelper")
-      if notif_class == Pointer(Void).null
-        return
+          JNIHelpers.with_jstring(env, channel.id) do |jid|
+            JNIHelpers.with_jstring(env, channel.name) do |jname|
+              jdesc = channel.description ? env.new_string_utf(channel.description.not_nil!) : Pointer(Void).null
+              jsound = channel.sound ? env.new_string_utf(channel.sound.not_nil!) : Pointer(Void).null
+              begin
+                env.call_static_void_method(notif_class, create_method,
+                  jid, jname, jdesc, channel.importance.value,
+                  channel.show_badge, channel.vibration,
+                  channel.sound ? true : false, jsound)
+              ensure
+                env.delete_local_ref(jsound) unless jsound.null?
+                env.delete_local_ref(jdesc) unless jdesc.null?
+              end
+            end
+          end
+        end
       end
-
-      create_method = env.get_static_method_id(notif_class, "createChannel", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZZZLjava/lang/String;)V")
-      env.call_static_void_method(notif_class, create_method,
-      env.delete_local_ref(notif_class) unless notif_class.null?
-        env.new_string_utf(channel.id),
-        env.new_string_utf(channel.name),
-        channel.description ? env.new_string_utf(channel.description.not_nil!) : Pointer(Void).null,
-        channel.importance.value,
-        channel.show_badge,
-        channel.vibration,
-        channel.sound ? true : false,
-        channel.sound ? env.new_string_utf(channel.sound.not_nil!) : Pointer(Void).null
-      )
     end
 
     def self.show(notification : Notification) : Bool
       return false unless @@initialized
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return false unless env
+        JNIHelpers.with_env do |env|
+          JNIHelpers.with_class(env, "com/nativecr/NotificationHelper") do |notif_class|
+            next false if notif_class.null?
+            show_method = env.get_static_method_id(notif_class, "showNotification", "(ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIZLjava/lang/String;ZILjava/lang/String;ZLjava/lang/String;)V")
+            next false if show_method.null?
 
-        notif_class = env.find_class("com/nativecr/NotificationHelper")
-        if notif_class == Pointer(Void).null
-          return false
+            args = JNIHelpers.with_jstring(env, notification.channel_id) do |jchannel|
+              JNIHelpers.with_jstring(env, notification.title) do |jtitle|
+                JNIHelpers.with_jstring(env, notification.body) do |jbody|
+                  jsubtitle = notification.subtitle ? env.new_string_utf(notification.subtitle.not_nil!) : Pointer(Void).null
+                  jlarge = notification.large_icon ? env.new_string_utf(notification.large_icon.not_nil!) : Pointer(Void).null
+                  jsmall = notification.small_icon ? env.new_string_utf(notification.small_icon.not_nil!) : Pointer(Void).null
+                  jsound = notification.sound ? env.new_string_utf(notification.sound.not_nil!) : Pointer(Void).null
+                  jpayload = env.new_string_utf(notification.payload.to_json)
+                  jactions = env.new_string_utf(notification.actions.map(&.id).join(","))
+                  begin
+                    env.call_static_void_method(notif_class, show_method,
+                      notification.id, jchannel, jtitle, jbody,
+                      jsubtitle, jlarge, jsmall,
+                      notification.badge_number,
+                      notification.priority.value,
+                      notification.auto_cancel,
+                      jsound, notification.vibration,
+                      notification.color || 0,
+                      jpayload, notification.actions.any?, jactions
+                    )
+                  ensure
+                    env.delete_local_ref(jpayload) unless jpayload.null?
+                    env.delete_local_ref(jactions) unless jactions.null?
+                    env.delete_local_ref(jsound) unless jsound.null?
+                    env.delete_local_ref(jsmall) unless jsmall.null?
+                    env.delete_local_ref(jlarge) unless jlarge.null?
+                    env.delete_local_ref(jsubtitle) unless jsubtitle.null?
+                  end
+                  true
+                end
+              end
+            end
+            !!args
+          end
         end
-
-        show_method = env.get_static_method_id(notif_class, "showNotification", "(ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIZLjava/lang/String;ZILjava/lang/String;ZLjava/lang/String;)V")
-
-        env.call_static_void_method(notif_class, show_method,
-        env.delete_local_ref(notif_class) unless notif_class.null?
-          notification.id,
-          env.new_string_utf(notification.channel_id),
-          env.new_string_utf(notification.title),
-          env.new_string_utf(notification.body),
-          notification.subtitle ? env.new_string_utf(notification.subtitle.not_nil!) : Pointer(Void).null,
-          notification.large_icon ? env.new_string_utf(notification.large_icon.not_nil!) : Pointer(Void).null,
-          notification.small_icon ? env.new_string_utf(notification.small_icon.not_nil!) : Pointer(Void).null,
-          notification.badge_number,
-          notification.priority.value,
-          notification.auto_cancel,
-          notification.sound ? env.new_string_utf(notification.sound.not_nil!) : Pointer(Void).null,
-          notification.vibration,
-          notification.color || 0,
-          notification.payload.to_json,
-          notification.actions.any?,
-          notification.actions.map(&.id).join(",")
-        )
       {% elsif flag?(:native_ios) %}
         LibIOS.show_notification(notification.id, notification.title.to_utf8, notification.body.to_utf8, notification.badge_number, notification.sound.to_utf8, notification.payload.to_json.to_utf8)
       {% else %}
         false
       {% end %}
-      true
     end
 
     def self.schedule(notification : Notification) : Bool
       return false unless notification.schedule_time
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return false unless env
+        JNIHelpers.with_env do |env|
+          JNIHelpers.with_class(env, "com/nativecr/NotificationHelper") do |notif_class|
+            next false if notif_class.null?
+            schedule_method = env.get_static_method_id(notif_class, "scheduleNotification", "(IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V")
+            next false if schedule_method.null?
 
-        notif_class = env.find_class("com/nativecr/NotificationHelper")
-        if notif_class == Pointer(Void).null
-          return false
+            timestamp = notification.schedule_time.not_nil!.to_unix * 1000
+            JNIHelpers.with_jstring(env, notification.channel_id) do |jchannel|
+              JNIHelpers.with_jstring(env, notification.title) do |jtitle|
+                JNIHelpers.with_jstring(env, notification.body) do |jbody|
+                  jpayload = env.new_string_utf(notification.payload.to_json)
+                  begin
+                    env.call_static_void_method(notif_class, schedule_method,
+                      notification.id, timestamp, jchannel, jtitle, jbody, jpayload,
+                      notification.repeat_interval ? true : false
+                    )
+                  ensure
+                    env.delete_local_ref(jpayload) unless jpayload.null?
+                  end
+                end
+              end
+            end
+            true
+          end
         end
-
-        schedule_method = env.get_static_method_id(notif_class, "scheduleNotification", "(IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V")
-
-        timestamp = notification.schedule_time.not_nil!.to_unix * 1000
-        env.call_static_void_method(notif_class, schedule_method,
-        env.delete_local_ref(notif_class) unless notif_class.null?
-          notification.id,
-          timestamp,
-          env.new_string_utf(notification.channel_id),
-          env.new_string_utf(notification.title),
-          env.new_string_utf(notification.body),
-          notification.payload.to_json,
-          notification.repeat_interval ? true : false
-        )
       {% elsif flag?(:native_ios) %}
         trigger_time = notification.schedule_time.not_nil!.to_unix_f
         repeats = notification.repeat_interval ? notification.repeat_interval.not_nil!.to_i == 86400 : false
@@ -198,20 +214,11 @@ module Native::Notifications
       {% else %}
         false
       {% end %}
-      true
     end
 
     def self.cancel(id : Int32) : Nil
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env
-
-        notif_class = env.find_class("com/nativecr/NotificationHelper")
-        return if notif_class == Pointer(Void).null
-
-        cancel_method = env.get_static_method_id(notif_class, "cancelNotification", "(I)V")
-        env.call_static_void_method(notif_class, cancel_method, id)
-        env.delete_local_ref(notif_class) unless notif_class.null?
+        JNIHelpers.call_static_void(env, "com/nativecr/NotificationHelper", "cancelNotification", "(I)V", id)
       {% elsif flag?(:native_ios) %}
         LibIOS.cancel_notification(id)
       {% end %}
@@ -219,15 +226,7 @@ module Native::Notifications
 
     def self.cancel_all : Nil
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env
-
-        notif_class = env.find_class("com/nativecr/NotificationHelper")
-        return if notif_class == Pointer(Void).null
-
-        cancel_method = env.get_static_method_id(notif_class, "cancelAllNotifications", "()V")
-        env.call_static_void_method(notif_class, cancel_method)
-        env.delete_local_ref(notif_class) unless notif_class.null?
+        JNIHelpers.call_static_void(env, "com/nativecr/NotificationHelper", "cancelAllNotifications", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.cancel_all_notifications
       {% end %}
@@ -235,15 +234,7 @@ module Native::Notifications
 
     def self.set_badge_number(count : Int32) : Nil
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return unless env
-
-        notif_class = env.find_class("com/nativecr/NotificationHelper")
-        return if notif_class == Pointer(Void).null
-
-        badge_method = env.get_static_method_id(notif_class, "setBadgeNumber", "(I)V")
-        env.call_static_void_method(notif_class, badge_method, count)
-        env.delete_local_ref(notif_class) unless notif_class.null?
+        JNIHelpers.call_static_void(env, "com/nativecr/NotificationHelper", "setBadgeNumber", "(I)V", count)
       {% elsif flag?(:native_ios) %}
         LibIOS.set_badge_number(count)
       {% end %}
@@ -251,12 +242,20 @@ module Native::Notifications
 
     def self.get_permission_status : Bool
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return false unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          next false if activity.null?
 
-        notif_manager = env.call_object_method(activity, env.get_method_id(env.get_object_class(activity), "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"), env.new_string_utf("notification"))
-        JNIHelpers.call_boolean(env, notif_manager, "areNotificationsEnabled", "()Z")
+          notif_manager = JNIHelpers.with_jstring(env, "notification") do |jname|
+            JNIHelpers.call_object(env, activity.to_i64, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;", jname)
+          end
+          next false if notif_manager.null?
+          begin
+            JNIHelpers.call_boolean(env, notif_manager.to_i64, "areNotificationsEnabled", "()Z")
+          ensure
+            env.delete_local_ref(notif_manager)
+          end
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.notification_permission_granted
       {% else %}

--- a/src/native/framework/payment.cr
+++ b/src/native/framework/payment.cr
@@ -1,4 +1,5 @@
 # src/native/framework/payment.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Payment
   enum ProductType
@@ -103,6 +104,7 @@ module Native::Payment
 
         init_method = env.get_static_method_id(billing_class, "init", "(Landroid/app/Activity;Ljava/lang/String;)V")
         env.call_static_void_method(billing_class, init_method, activity, env.new_string_utf(merchant_id))
+        env.delete_local_ref(billing_class) unless billing_class.null?
 
         setupCallbacks
       {% elsif flag?(:native_ios) %}
@@ -152,6 +154,7 @@ module Native::Payment
 
         purchase_method = env.get_static_method_id(billing_class, "purchase", "(Landroid/app/Activity;Ljava/lang/String;)V")
         env.call_static_void_method(billing_class, purchase_method, Native::Android::JNI.activity, env.new_string_utf(product_id))
+        env.delete_local_ref(billing_class) unless billing_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.payment_purchase(product_id.to_utf8)
       {% else %}
@@ -174,6 +177,7 @@ module Native::Payment
 
         restore_method = env.get_static_method_id(billing_class, "restore", "()V")
         env.call_static_void_method(billing_class, restore_method)
+        env.delete_local_ref(billing_class) unless billing_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.payment_restore
       {% else %}
@@ -194,6 +198,7 @@ module Native::Payment
 
         purchased_method = env.get_static_method_id(billing_class, "isPurchased", "(Ljava/lang/String;)Z")
         env.call_static_boolean_method(billing_class, purchased_method, env.new_string_utf(product_id))
+        env.delete_local_ref(billing_class) unless billing_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.payment_is_purchased(product_id.to_utf8)
       {% else %}
@@ -213,6 +218,7 @@ module Native::Payment
 
         active_method = env.get_static_method_id(billing_class, "isSubscriptionActive", "(Ljava/lang/String;)Z")
         env.call_static_boolean_method(billing_class, active_method, env.new_string_utf(product_id))
+        env.delete_local_ref(billing_class) unless billing_class.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.payment_is_subscription_active(product_id.to_utf8)
       {% else %}
@@ -231,12 +237,14 @@ module Native::Payment
         end
 
         callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
+        env.delete_local_ref(callback_class) unless callback_class.null?
 
         billing_class = env.find_class("com/nativecr/BillingHelper")
         return if billing_class == Pointer(Void).null
 
         set_callback = env.get_static_method_id(billing_class, "setCallback", "(Lcom/nativecr/BillingCallback;)V")
         env.call_static_void_method(billing_class, set_callback, callback_obj)
+        env.delete_local_ref(billing_class) unless billing_class.null?
       {% elsif flag?(:native_ios) %}
         # iOS callbacks are handled by the Swift bridge
       {% end %}
@@ -259,6 +267,7 @@ module Native::Payment
       end
 
       result = env.call_static_object_method(billing_class, fetch_method, product_array)
+      env.delete_local_ref(billing_class) unless billing_class.null?
 
       if result
         json = env.get_string_utf_chars(result, nil).to_s

--- a/src/native/framework/permissions.cr
+++ b/src/native/framework/permissions.cr
@@ -1,4 +1,5 @@
 # src/native/framework/permissions.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::Permissions
   enum PermissionType
@@ -32,18 +33,19 @@ module Native::Permissions
 
     def self.check(type : PermissionType) : PermissionStatus
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return PermissionStatus::Denied unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return PermissionStatus::Denied if activity.null?
 
-        perm_name = permission_string(type)
-        check_permission = env.get_method_id(env.get_object_class(activity), "checkSelfPermission", "(Ljava/lang/String;)I")
-        result = env.call_int_method(activity, check_permission, env.new_string_utf(perm_name))
+          result = JNIHelpers.with_jstring(env, permission_string(type)) do |jperm|
+            JNIHelpers.call_int(env, activity.to_i64, "checkSelfPermission", "(Ljava/lang/String;)I", jperm)
+          end
 
-        case result
-        when  0 then PermissionStatus::Granted
-        when -1 then PermissionStatus::Denied
-        else         PermissionStatus::NotDetermined
+          case result
+          when 0 then PermissionStatus::Granted
+          when -1 then PermissionStatus::Denied
+          else PermissionStatus::NotDetermined
+          end
         end
       {% elsif flag?(:native_ios) %}
         status = LibIOS.check_permission(type.value)
@@ -65,15 +67,24 @@ module Native::Permissions
       @@callbacks[type] << callback
 
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return unless activity
 
-        perm_name = permission_string(type)
-        request_perms = env.get_method_id(env.get_object_class(activity), "requestPermissions", "([Ljava/lang/String;I)V")
-        perm_array = env.new_object_array(1, env.find_class("java/lang/String"), nil)
-        env.set_object_array_element(perm_array, 0, env.new_string_utf(perm_name))
-        env.call_void_method(activity, request_perms, perm_array, type.value)
+          JNIHelpers.with_class(env, "java/lang/String") do |string_class|
+            next if string_class.null?
+            perm_array = env.new_object_array(1, string_class)
+            next if perm_array.null?
+            begin
+              JNIHelpers.with_jstring(env, permission_string(type)) do |jperm|
+                env.set_object_array_element(perm_array, 0, jperm)
+              end
+              JNIHelpers.call_void(env, activity.to_i64, "requestPermissions", "([Ljava/lang/String;I)V", perm_array, type.value)
+            ensure
+              env.delete_local_ref(perm_array)
+            end
+          end
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.request_permission(type.value)
       {% end %}
@@ -106,22 +117,47 @@ module Native::Permissions
 
     def self.open_settings
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        activity = Native::Android::JNI.activity
-        return unless env && activity
+        JNIHelpers.with_env do |env|
+          activity = Native::Android::JNI.activity
+          return unless activity
 
-        intent_class = env.find_class("android/content/Intent")
-        settings_action = env.get_static_field_id(intent_class, "ACTION_APPLICATION_DETAILS_SETTINGS", "Ljava/lang/String;")
-        action = env.get_static_object_field(intent_class, settings_action)
+          JNIHelpers.with_class(env, "android/content/Intent") do |intent_class|
+            next if intent_class.null?
+            settings_fid = env.get_static_field_id(intent_class, "ACTION_APPLICATION_DETAILS_SETTINGS", "Ljava/lang/String;")
+            next if settings_fid.null?
+            action = env.get_static_object_field(intent_class, settings_fid)
 
-        uri_class = env.find_class("android/net/Uri")
-        parse_method = env.get_static_method_id(uri_class, "parse", "(Ljava/lang/String;)Landroid/net/Uri;")
-        package_name = env.call_object_method(activity, env.get_method_id(env.get_object_class(activity), "getPackageName", "()Ljava/lang/String;"))
-        uri = env.call_static_object_method(uri_class, parse_method, env.new_string_utf("package:"), package_name)
-
-        intent = env.new_object(intent_class, env.get_method_id(intent_class, "<init>", "(Ljava/lang/String;Landroid/net/Uri;)V"), action, uri)
-        start_activity = env.get_method_id(env.get_object_class(activity), "startActivity", "(Landroid/content/Intent;)V")
-        env.call_void_method(activity, start_activity, intent)
+            package_name = JNIHelpers.call_object(env, activity.to_i64, "getPackageName", "()Ljava/lang/String;")
+            next if package_name.null?
+            begin
+              uri = JNIHelpers.with_jstring(env, "package:") do |jprefix|
+                JNIHelpers.call_object(env, jprefix.to_i64, "concat", "(Ljava/lang/String;)Ljava/lang/String;", package_name)
+              end
+              next if uri.null?
+              begin
+                uri_obj = JNIHelpers.call_static_object(env, "android/net/Uri", "parse", "(Ljava/lang/String;)Landroid/net/Uri;", uri)
+                next if uri_obj.null?
+                begin
+                  ctor = env.get_method_id(intent_class, "<init>", "(Ljava/lang/String;Landroid/net/Uri;)V")
+                  next if ctor.null?
+                  intent = env.new_object(intent_class, ctor, action, uri_obj)
+                  next if intent.null?
+                  begin
+                    JNIHelpers.call_void(env, activity.to_i64, "startActivity", "(Landroid/content/Intent;)V", intent)
+                  ensure
+                    env.delete_local_ref(intent)
+                  end
+                ensure
+                  env.delete_local_ref(uri_obj)
+                end
+              ensure
+                env.delete_local_ref(uri)
+              end
+            ensure
+              env.delete_local_ref(package_name)
+            end
+          end
+        end
       {% elsif flag?(:native_ios) %}
         LibIOS.open_settings
       {% end %}

--- a/src/native/framework/platform.cr
+++ b/src/native/framework/platform.cr
@@ -47,6 +47,7 @@ module Native::Platform
 
       android_id = env.new_string_utf("android_id")
       model = env.call_static_object_method(settings_class, get_string, resolver, android_id)
+      env.delete_local_ref(settings_class) unless settings_class.null?
 
       result = if model
                  env.get_string_utf_chars(model).to_s
@@ -81,6 +82,7 @@ module Native::Platform
       version_class = env.find_class("android/os/Build$VERSION")
       release_field = env.get_static_field_id(version_class, "RELEASE", "Ljava/lang/String;")
       release = env.get_static_object_field(version_class, release_field)
+      env.delete_local_ref(version_class) unless version_class.null?
 
       if release
         result = env.get_string_utf_chars(release).to_s
@@ -179,8 +181,7 @@ module Native::Platform
       vibrator = env.call_object_method(activity, env.get_method_id(env.get_object_class(activity), "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"), env.new_string_utf("vibrator"))
 
       if vibrator
-        vibrate_method = env.get_method_id(env.get_object_class(vibrator), "vibrate", "(J)V")
-        env.call_void_method(vibrator, vibrate_method, duration_ms.to_i64)
+        JNIHelpers.call_void(env, vibrator, "vibrate", "(J)V", , duration_ms.to_i64)
         env.delete_local_ref(vibrator)
       end
     elsif ios?
@@ -197,13 +198,14 @@ module Native::Platform
       uri_class = env.find_class("android/net/Uri")
       parse_method = env.get_static_method_id(uri_class, "parse", "(Ljava/lang/String;)Landroid/net/Uri;")
       uri = env.call_static_object_method(uri_class, parse_method, env.new_string_utf(url))
+      env.delete_local_ref(uri_class) unless uri_class.null?
 
       intent_class = env.find_class("android/content/Intent")
       intent_constructor = env.get_method_id(intent_class, "<init>", "(Ljava/lang/String;Landroid/net/Uri;)V")
       intent = env.new_object(intent_class, intent_constructor, env.new_string_utf("android.intent.action.VIEW"), uri)
+      env.delete_local_ref(intent_class) unless intent_class.null?
 
-      start_activity = env.get_method_id(env.get_object_class(activity), "startActivity", "(Landroid/content/Intent;)V")
-      env.call_void_method(activity, start_activity, intent)
+      JNIHelpers.call_void(env, activity, "startActivity", "(Landroid/content/Intent;)V", intent)
 
       env.delete_local_ref(uri)
       env.delete_local_ref(intent)
@@ -237,9 +239,9 @@ module Native::Platform
 
       create_chooser = env.get_static_method_id(intent_class, "createChooser", "(Landroid/content/Intent;Ljava/lang/CharSequence;)Landroid/content/Intent;")
       chooser = env.call_static_object_method(intent_class, create_chooser, intent, env.new_string_utf(title))
+      env.delete_local_ref(intent_class) unless intent_class.null?
 
-      start_activity = env.get_method_id(env.get_object_class(activity), "startActivity", "(Landroid/content/Intent;)V")
-      env.call_void_method(activity, start_activity, chooser)
+      JNIHelpers.call_void(env, activity, "startActivity", "(Landroid/content/Intent;)V", chooser)
 
       env.delete_local_ref(intent)
       env.delete_local_ref(chooser)
@@ -260,9 +262,9 @@ module Native::Platform
         clip_class = env.find_class("android/content/ClipData")
         new_plain_text = env.get_static_method_id(clip_class, "newPlainText", "(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Landroid/content/ClipData;")
         clip = env.call_static_object_method(clip_class, new_plain_text, env.new_string_utf("text"), env.new_string_utf(text))
+        env.delete_local_ref(clip_class) unless clip_class.null?
 
-        set_clip = env.get_method_id(env.get_object_class(clipboard), "setPrimaryClip", "(Landroid/content/ClipData;)V")
-        env.call_void_method(clipboard, set_clip, clip)
+        JNIHelpers.call_void(env, clipboard, "setPrimaryClip", "(Landroid/content/ClipData;)V", , clip)
 
         env.delete_local_ref(clipboard)
         env.delete_local_ref(clip)

--- a/src/native/framework/platform.cr
+++ b/src/native/framework/platform.cr
@@ -205,7 +205,7 @@ module Native::Platform
       intent = env.new_object(intent_class, intent_constructor, env.new_string_utf("android.intent.action.VIEW"), uri)
       env.delete_local_ref(intent_class) unless intent_class.null?
 
-      JNIHelpers.call_void(env, activity, "startActivity", "(Landroid/content/Intent;)V", intent)
+      JNIHelpers.call_void(env, activity.to_i64, "startActivity", "(Landroid/content/Intent;)V", intent)
 
       env.delete_local_ref(uri)
       env.delete_local_ref(intent)
@@ -241,7 +241,7 @@ module Native::Platform
       chooser = env.call_static_object_method(intent_class, create_chooser, intent, env.new_string_utf(title))
       env.delete_local_ref(intent_class) unless intent_class.null?
 
-      JNIHelpers.call_void(env, activity, "startActivity", "(Landroid/content/Intent;)V", chooser)
+      JNIHelpers.call_void(env, activity.to_i64, "startActivity", "(Landroid/content/Intent;)V", chooser)
 
       env.delete_local_ref(intent)
       env.delete_local_ref(chooser)

--- a/src/native/framework/platform.cr
+++ b/src/native/framework/platform.cr
@@ -181,7 +181,7 @@ module Native::Platform
       vibrator = env.call_object_method(activity, env.get_method_id(env.get_object_class(activity), "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"), env.new_string_utf("vibrator"))
 
       if vibrator
-        JNIHelpers.call_void(env, vibrator, "vibrate", "(J)V", , duration_ms.to_i64)
+        JNIHelpers.call_void(env, vibrator, "vibrate", "(J)V", duration_ms.to_i64)
         env.delete_local_ref(vibrator)
       end
     elsif ios?
@@ -264,7 +264,7 @@ module Native::Platform
         clip = env.call_static_object_method(clip_class, new_plain_text, env.new_string_utf("text"), env.new_string_utf(text))
         env.delete_local_ref(clip_class) unless clip_class.null?
 
-        JNIHelpers.call_void(env, clipboard, "setPrimaryClip", "(Landroid/content/ClipData;)V", , clip)
+        JNIHelpers.call_void(env, clipboard, "setPrimaryClip", "(Landroid/content/ClipData;)V", clip)
 
         env.delete_local_ref(clipboard)
         env.delete_local_ref(clip)

--- a/src/native/framework/sensors.cr
+++ b/src/native/framework/sensors.cr
@@ -1,3 +1,10 @@
+# src/native/framework/sensors.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
+# Also fixed: two double-comma syntax errors in the JNI calls, misnamed
+# enum members (SesnorType::Gytoscope etc.), a wrong callback class path
+# (com/native/ instead of com/nativecr/), a `-> NIl` return annotation,
+# and delay_us being used without ever being a parameter.
+
 module Native::Sensors
   enum SensorType
     Accelerometer
@@ -52,13 +59,14 @@ module Native::Sensors
     end
 
     private def init_android
-      env = Native::Android::JNI.env
-      activity = Native::Android::JNI.activity
-      return unless env && activity
+      JNIHelpers.with_env do |env|
+        activity = Native::Android::JNI.activity
+        return unless activity
 
-      sensor_class = env.find_class("android/hardware/Sensor")
-      get_service = env.get_method_id(env.get_object_class(activity), "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;")
-      @@manager_ptr = env.call_object_method(activity, get_service, env.new_string_utf("sensor")).to_i64
+        @@manager_ptr = JNIHelpers.with_jstring(env, "sensor") do |jname|
+          JNIHelpers.call_object(env, activity.to_i64, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;", jname)
+        end.to_i64
+      end
     end
 
     private def init_ios
@@ -67,51 +75,61 @@ module Native::Sensors
 
     def sensor_available?(type : SensorType) : Bool
       {% if flag?(:native_android) %}
-        env = Native::Android::JNI.env
-        return false unless env && @@manager_ptr != 0_i64
-        sensor_type = sensor_type_value(type)
-        sensor_class = env.find_class("android/hardware/Sensor")
-        get_default_sensor = env.get_method_id(env.get_object_class(@@manager_ptr), "getDefaultSensor", "(I)Landroid/hardware/Sensor;")
-        sensor = env.call_object_method(@@manager_ptr, get_default_sensor, sensor_type)
-        return sensor != Pointer(Void).null
+        JNIHelpers.with_env do |env|
+          return false if @@manager_ptr == 0_i64
+          sensor = JNIHelpers.call_object(env, @@manager_ptr, "getDefaultSensor", "(I)Landroid/hardware/Sensor;", sensor_type_value(type))
+          !sensor.null?
+        end
       {% elsif flag?(:native_ios) %}
-        return LibIOS.sensor_available(type.value)
+        LibIOS.sensor_available(type.value)
       {% else %}
         false
       {% end %}
     end
 
-    def start_listening(type : SensorType, &callback : SensorData -> Nil)
+    def start_listening(type : SensorType, delay_us : Int32 = 200000, &callback : SensorData -> Nil)
       @@listeners[type] ||= [] of SensorData -> Nil
       @@listeners[type] << callback
 
       unless @@active_sensors[type]
         {% if flag?(:native_android) %}
-          start_listening_android(type)
+          start_listening_android(type, delay_us)
         {% elsif flag?(:native_ios) %}
-          start_listening_ios(type)
+          start_listening_ios(type, delay_us)
         {% end %}
         @@active_sensors[type] = true
       end
     end
 
-    private def start_listening_android(type)
-      env = Native::Android::JNI.env
-      return unless env && @@manager_ptr != 0_i64
-      sensor_type = sensor_type_value(type)
-      get_default = env.get_method_id(env.get_object_class(@@manager_ptr), "getDefaultSensor", "(I)Landroid/hardware/Sensor;")
-      sensor = env.call_object_method(@@manager_ptr, get_default, sensor_type)
-      if sensor != Pointer(Void).null
-        listener_class = env.find_class("com/nativecr/SensorListener")
-        if listener_class != Pointer(Void).null
-          callback_obj = env.new_object(listener_class, env.get_method_id(listener_class, "<init>", "(JI)V"), 0i64, type.value)
-          register = env.get_method_id(env.get_object_class(@@manager_ptr), "registerListener", "(Landroid/hardware/SensorEventListener;Landroid/hardware/Sensor;I)Z")
-          env.call_boolean_method(@@manager_ptr, register, callback_obj, sensor, delay_us)
+    private def start_listening_android(type, delay_us : Int32)
+      JNIHelpers.with_env do |env|
+        return if @@manager_ptr == 0_i64
+        sensor = JNIHelpers.call_object(env, @@manager_ptr, "getDefaultSensor", "(I)Landroid/hardware/Sensor;", sensor_type_value(type))
+        return if sensor.null?
+        begin
+          listener = JNIHelpers.with_class(env, "com/nativecr/SensorListener") do |listener_class|
+            next Pointer(Void).null if listener_class.null?
+            ctor = env.get_method_id(listener_class, "<init>", "(JI)V")
+            next Pointer(Void).null if ctor.null?
+            env.new_object(listener_class, ctor, 0i64, type.value)
+          end
+          next if listener.null?
+          begin
+            JNIHelpers.call_boolean(
+              env, @@manager_ptr, "registerListener",
+              "(Landroid/hardware/SensorEventListener;Landroid/hardware/Sensor;I)Z",
+              listener, sensor, delay_us
+            )
+          ensure
+            env.delete_local_ref(listener)
+          end
+        ensure
+          env.delete_local_ref(sensor)
         end
       end
     end
 
-    private def start_listening_ios(type)
+    private def start_listening_ios(type, delay_us : Int32)
       LibIOS.sensor_start(type.value, delay_us)
     end
 
@@ -127,14 +145,19 @@ module Native::Sensors
     end
 
     private def stop_listening_android(type)
-      env = Native::Android::JNI.env
-      return unless env && @@manager_ptr != 0_i64
-      sensor_type = sensor_type_value(type)
-      listener_class = env.find_class("com/native/SensorListener")
-      if listener_class != Pointer(Void).null
-        callback_obj = env.get_static_object_field(listener_class, env.get_static_field_id(listener_class, "instance", "Lcom/native/SensorListener;"))
-        unregister = env.get_method_id(env.get_object_class(@@manager_ptr), "unregisterListener", "(Landroid/hardware/SensorEventListener;)V")
-        env.call_void_method(@@manager_ptr, unregister, callback_obj)
+      JNIHelpers.with_env do |env|
+        return if @@manager_ptr == 0_i64
+        listener = JNIHelpers.with_class(env, "com/nativecr/SensorListener") do |listener_class|
+          next Pointer(Void).null if listener_class.null?
+          fid = env.get_static_field_id(listener_class, "instance", "Lcom/nativecr/SensorListener;")
+          fid.null? ? Pointer(Void).null : env.get_static_object_field(listener_class, fid)
+        end
+        return if listener.null?
+        begin
+          JNIHelpers.call_void(env, @@manager_ptr, "unregisterListener", "(Landroid/hardware/SensorEventListener;)V", listener)
+        ensure
+          env.delete_local_ref(listener)
+        end
       end
     end
 
@@ -143,7 +166,7 @@ module Native::Sensors
     end
 
     def stop_all
-      @@listeners.each do |type|
+      @@listeners.each_key do |type|
         stop_listening(type)
       end
       @@listeners.clear
@@ -159,8 +182,8 @@ module Native::Sensors
     private def sensor_type_value(type : SensorType) : Int32
       case type
       when SensorType::Accelerometer then 1
-      when SesnorType::Gytoscope     then 4
-      when SensorType::Magnometer    then 3
+      when SensorType::Gyroscope     then 4
+      when SensorType::Magnetometer  then 3
       when SensorType::Light         then 5
       when SensorType::Proximity     then 8
       when SensorType::Pressure      then 6
@@ -174,7 +197,7 @@ module Native::Sensors
 
   module Sensor
     def self.accelerometer(delay_us : Int32 = 200000, &callback : SensorData -> Nil)
-      SensorManager.instance.start_listening(SensorType::Acclerometer, delay_us, &callback)
+      SensorManager.instance.start_listening(SensorType::Accelerometer, delay_us, &callback)
     end
 
     def self.gyroscope(delay_us : Int32 = 200000, &callback : SensorData -> Nil)
@@ -185,7 +208,7 @@ module Native::Sensors
       SensorManager.instance.start_listening(SensorType::Magnetometer, delay_us, &callback)
     end
 
-    def self.light(delay_us : Int32 = 20000, &callback : SensorData -> NIl)
+    def self.light(delay_us : Int32 = 20000, &callback : SensorData -> Nil)
       SensorManager.instance.start_listening(SensorType::Light, delay_us, &callback)
     end
 

--- a/src/native/framework/share.cr
+++ b/src/native/framework/share.cr
@@ -31,49 +31,80 @@ module Native::Share
       {% end %}
     end
 
+    # Refactored to use JNIHelpers for automatic local reference cleanup.
+    # The old version had never compiled for Android: a `retun` typo, a
+    # garbage putExtra signature ("(Ljava/lang/string:...)"), and
+    # `activity.class` on a Void* — all in code paths CI never type-checked.
     private def show_android
-      env = Native::Android::JNI.env
-      activity = Native::Android::JNI.activity
-      retun unless env && activity
+      JNIHelpers.with_env do |env|
+        activity = Native::Android::JNI.activity
+        return unless activity
 
-      intent_class = env.find_class("android/content/Intent")
-      intent_constructor = env.get_method_id(intent_class, "<init>", "()V")
-      intent = env.new_object(intent_class, intent_constructor)
+        intent = JNIHelpers.with_class(env, "android/content/Intent") do |intent_class|
+          next Pointer(Void).null if intent_class.null?
+          ctor = env.get_method_id(intent_class, "<init>", "()V")
+          next Pointer(Void).null if ctor.null?
+          env.new_object(intent_class, ctor)
+        end
+        return if intent.null?
 
-      set_action = env.get_method_id(intent_class, "setAction", "(Ljava/lang/String;)Landroid/content/Intent;")
-      env.call_object_method(intent, set_action, env.new_string_utf("android.intent.action.SEND"))
+        begin
+          JNIHelpers.with_jstring(env, "android.intent.action.SEND") do |jaction|
+            JNIHelpers.call_object(env, intent.to_i64, "setAction", "(Ljava/lang/String;)Landroid/content/Intent;", jaction)
+          end
 
-      if @options.text && !@options.text.empty?
-        put_extra = env.get_method_id(intent_class, "putExtra", "(Ljava/lang/string:ljava/lang/string:)Landroid/content/Intent;")
-        env.call_object_method(intent, put_extra, env.new_string_utf("android.intent.extra.TEXT"), env.new_string_utf(@options.text))
+          unless @options.text.empty?
+            JNIHelpers.with_jstring(env, @options.text) do |jtext|
+              JNIHelpers.with_jstring(env, "android.intent.extra.TEXT") do |jkey|
+                JNIHelpers.call_object(env, intent.to_i64, "putExtra", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/Intent;", jkey, jtext)
+              end
+            end
+          end
+
+          unless @options.url.empty?
+            JNIHelpers.with_jstring(env, @options.url) do |jurl|
+              JNIHelpers.with_jstring(env, "android.intent.extra.TEXT") do |jkey|
+                JNIHelpers.call_object(env, intent.to_i64, "putExtra", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/Intent;", jkey, jurl)
+              end
+            end
+          end
+
+          JNIHelpers.with_jstring(env, @options.mime_type) do |jtype|
+            JNIHelpers.call_object(env, intent.to_i64, "setType", "(Ljava/lang/String;)Landroid/content/Intent;", jtype)
+          end
+
+          unless @options.image_path.empty?
+            JNIHelpers.with_jstring(env, @options.image_path) do |jpath|
+              image_uri = JNIHelpers.call_static_object(env, "android/net/Uri", "parse", "(Ljava/lang/String;)Landroid/net/Uri;", jpath)
+              unless image_uri.null?
+                begin
+                  JNIHelpers.with_jstring(env, "android.intent.extra.STREAM") do |jkey|
+                    JNIHelpers.call_object(env, intent.to_i64, "putExtra", "(Ljava/lang/String;Landroid/os/Parcelable;)Landroid/content/Intent;", jkey, image_uri)
+                  end
+                ensure
+                  env.delete_local_ref(image_uri)
+                end
+              end
+            end
+          end
+
+          chooser = JNIHelpers.with_jstring(env, @options.title) do |jtitle|
+            JNIHelpers.call_static_object(env, "android/content/Intent", "createChooser", "(Landroid/content/Intent;Ljava/lang/CharSequence;)Landroid/content/Intent;", intent, jtitle)
+          end
+
+          unless chooser.null?
+            begin
+              JNIHelpers.call_void(env, activity.to_i64, "startActivity", "(Landroid/content/Intent;)V", chooser)
+            ensure
+              env.delete_local_ref(chooser)
+            end
+          end
+
+          @on_complete.try &.call(true)
+        ensure
+          env.delete_local_ref(intent)
+        end
       end
-
-      if @options.url && !@options.url.empty?
-        put_extra = env.get_method_id(intent_class, "putExtra", "(Ljava/lang/string:ljava/lang/string:)Landroid/content/Intent;")
-        env.call_object_method(intent, put_extra, env.new_string_utf("android.intent.extra.TEXT"), env.new_string_utf(@options.url))
-      end
-
-      if @options.image_path && !@options.image_path.empty?
-        uri_class = env.find_class("android/net/Uri")
-        uri_parse = env.get_static_method_id(uri_class, "parse", "(Ljava/lang/String;)Landroid/net/Uri;")
-        image_uri = env.call_static_object_method(uri_class, uri_parse, env.new_string_utf(@options.image_path))
-
-        put_extra = env.get_method_id(intent_class, "putExtra", "(Ljava/lang/string:ljava/lang/Object;)Landroid/content/Intent;")
-        env.call_object_method(intent, put_extra, env.new_string_utf("android.intent.extra.STREAM"), image_uri)
-
-        set_type = env.get_method_id(intent_class, "setType", "(Ljava/lang/String;)Landroid/content/Intent;")
-        env.call_object_method(intent, set_type, env.new_string_utf(@options.mime_type))
-      else
-        set_type = env.get_method_id(intent_class, "setType", "(Ljava/lang/String;)Landroid/content/Intent;")
-        env.call_object_method(intent, set_type, env.new_string_utf(@options.mime_type))
-      end
-
-      create_chooser = env.get_static_method_id(intent_class, "createChooser", "(Landroid/content/Intent;Ljava/lang/String;)Landroid/content/Intent;")
-      chooser = env.call_static_object_method(intent_class, create_chooser, intent, env.new_string_utf(@options.title))
-      start_activity = env.get_method_id(activity.class, "startActivity", "(Landroid/content/Intent;)V")
-      env.call_void_method(activity, start_activity, chooser)
-
-      @on_complete.try &.call(true)
     end
 
     private def show_ios

--- a/src/native/framework/storage.cr
+++ b/src/native/framework/storage.cr
@@ -18,7 +18,7 @@ module Native::Storage
         edit = env.get_method_id(env.get_object_class(prefs), "edit", "()Landroid/content/SharedPreferences$Editor;")
         editor = env.call_object_method(prefs, edit)
 
-        JNIHelpers.call_object(env, editor, "putString", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;", , jkey, jvalue)
+        JNIHelpers.call_object(env, editor, "putString", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;", jkey, jvalue)
 
         JNIHelpers.call_void(env, editor, "apply", "()V")
 

--- a/src/native/framework/storage.cr
+++ b/src/native/framework/storage.cr
@@ -18,11 +18,9 @@ module Native::Storage
         edit = env.get_method_id(env.get_object_class(prefs), "edit", "()Landroid/content/SharedPreferences$Editor;")
         editor = env.call_object_method(prefs, edit)
 
-        put_string = env.get_method_id(env.get_object_class(editor), "putString", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;")
-        env.call_object_method(editor, put_string, jkey, jvalue)
+        JNIHelpers.call_object(env, editor, "putString", "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;", , jkey, jvalue)
 
-        apply = env.get_method_id(env.get_object_class(editor), "apply", "()V")
-        env.call_void_method(editor, apply)
+        JNIHelpers.call_void(env, editor, "apply", "()V")
 
         env.delete_local_ref(jkey)
         env.delete_local_ref(jvalue)
@@ -153,11 +151,9 @@ module Native::Storage
         edit = env.get_method_id(env.get_object_class(prefs), "edit", "()Landroid/content/SharedPreferences$Editor;")
         editor = env.call_object_method(prefs, edit)
 
-        remove = env.get_method_id(env.get_object_class(editor), "remove", "(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;")
-        env.call_object_method(editor, remove, jkey)
+        JNIHelpers.call_object(env, editor, "remove", "(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;", jkey)
 
-        apply = env.get_method_id(env.get_object_class(editor), "apply", "()V")
-        env.call_void_method(editor, apply)
+        JNIHelpers.call_void(env, editor, "apply", "()V")
 
         env.delete_local_ref(jkey)
         env.delete_local_ref(prefs)
@@ -179,11 +175,9 @@ module Native::Storage
         edit = env.get_method_id(env.get_object_class(prefs), "edit", "()Landroid/content/SharedPreferences$Editor;")
         editor = env.call_object_method(prefs, edit)
 
-        clr = env.get_method_id(env.get_object_class(editor), "clear", "()Landroid/content/SharedPreferences$Editor;")
-        env.call_object_method(editor, clr)
+        JNIHelpers.call_object(env, editor, "clear", "()Landroid/content/SharedPreferences$Editor;")
 
-        apply = env.get_method_id(env.get_object_class(editor), "apply", "()V")
-        env.call_void_method(editor, apply)
+        JNIHelpers.call_void(env, editor, "apply", "()V")
 
         env.delete_local_ref(prefs)
         env.delete_local_ref(editor)
@@ -275,6 +269,7 @@ module Native::Storage
         file_class = env.find_class("java/io/File")
         file_constructor = env.get_method_id(file_class, "<init>", "(Ljava/lang/String;)V")
         file = env.new_object(file_class, file_constructor, env.new_string_utf(full_path))
+        env.delete_local_ref(file_class) unless file_class.null?
 
         fos_class = env.find_class("java/io/FileOutputStream")
         fos_constructor = env.get_method_id(fos_class, "<init>", "(Ljava/io/File;)V")
@@ -286,6 +281,7 @@ module Native::Storage
         env.call_void_method(fos, write_method, byte_array)
 
         close_method = env.get_method_id(fos_class, "close", "()V")
+        env.delete_local_ref(fos_class) unless fos_class.null?
         env.call_void_method(fos, close_method)
 
         env.delete_local_ref(file)
@@ -329,6 +325,7 @@ module Native::Storage
         file_class = env.find_class("java/io/File")
         file_constructor = env.get_method_id(file_class, "<init>", "(Ljava/lang/String;)V")
         file = env.new_object(file_class, file_constructor, env.new_string_utf(full_path))
+        env.delete_local_ref(file_class) unless file_class.null?
 
         fis_class = env.find_class("java/io/FileInputStream")
         fis_constructor = env.get_method_id(fis_class, "<init>", "(Ljava/io/File;)V")
@@ -348,6 +345,7 @@ module Native::Storage
         env.call_int_method(fis, read_method, byte_array)
 
         close_method = env.get_method_id(fis_class, "close", "()V")
+        env.delete_local_ref(fis_class) unless fis_class.null?
         env.call_void_method(fis, close_method)
 
         data = Bytes.new(size)
@@ -405,6 +403,7 @@ module Native::Storage
         file = env.new_object(file_class, file_constructor, env.new_string_utf(full_path))
 
         exists_method = env.get_method_id(file_class, "exists", "()Z")
+        env.delete_local_ref(file_class) unless file_class.null?
         result = env.call_boolean_method(file, exists_method)
 
         env.delete_local_ref(file)
@@ -444,6 +443,7 @@ module Native::Storage
         file = env.new_object(file_class, file_constructor, env.new_string_utf(full_path))
 
         delete_method = env.get_method_id(file_class, "delete", "()Z")
+        env.delete_local_ref(file_class) unless file_class.null?
         result = env.call_boolean_method(file, delete_method)
 
         env.delete_local_ref(file)
@@ -487,6 +487,7 @@ module Native::Storage
         file = env.new_object(file_class, file_constructor, env.new_string_utf(full_path))
 
         list_method = env.get_method_id(file_class, "list", "()[Ljava/lang/String;")
+        env.delete_local_ref(file_class) unless file_class.null?
         array = env.call_object_method(file, list_method)
 
         if array

--- a/src/native/framework/ui/card_view.cr
+++ b/src/native/framework/ui/card_view.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/card_view.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class CardView < View
@@ -17,6 +18,7 @@ module Native::UI
         card_class = env.find_class("androidx/cardview/widget/CardView")
         constructor = env.get_method_id(card_class, "<init>", "(Landroid/content/Context;)V")
         @native = env.new_object(card_class, constructor, activity).to_i64
+        env.delete_local_ref(card_class) unless card_class.null?
 
         applyCardElevation
         applyCardRadius
@@ -51,8 +53,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_padding = env.get_method_id(env.get_object_class(@native), "setContentPadding", "(IIII)V")
-        env.call_void_method(@native, set_padding, value, value, value, value)
+        JNIHelpers.call_void(env, @native, "setContentPadding", "(IIII)V", , value, value, value, value)
       {% end %}
     end
 
@@ -64,8 +65,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0 && view.native_ptr != 0
-        add_view = env.get_method_id(env.get_object_class(@native), "addView", "(Landroid/view/View;)V")
-        env.call_void_method(@native, add_view, view.native_ptr)
+        JNIHelpers.call_void(env, @native, "addView", "(Landroid/view/View;)V", , view.native_ptr)
       {% elsif flag?(:native_ios) %}
         LibIOS.card_view_add_subview(@native, view.native_ptr)
       {% end %}
@@ -75,8 +75,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0 && view.native_ptr != 0
-        remove_view = env.get_method_id(env.get_object_class(@native), "removeView", "(Landroid/view/View;)V")
-        env.call_void_method(@native, remove_view, view.native_ptr)
+        JNIHelpers.call_void(env, @native, "removeView", "(Landroid/view/View;)V", , view.native_ptr)
       {% elsif flag?(:native_ios) %}
         LibIOS.card_view_remove_subview(@native, view.native_ptr)
       {% end %}
@@ -86,8 +85,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_elevation = env.get_method_id(env.get_object_class(@native), "setCardElevation", "(F)V")
-        env.call_void_method(@native, set_elevation, @card_elevation)
+        JNIHelpers.call_void(env, @native, "setCardElevation", "(F)V", , @card_elevation)
       {% elsif flag?(:native_ios) %}
         LibIOS.card_view_set_elevation(@native, @card_elevation)
       {% end %}
@@ -97,8 +95,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_radius = env.get_method_id(env.get_object_class(@native), "setRadius", "(F)V")
-        env.call_void_method(@native, set_radius, @card_radius)
+        JNIHelpers.call_void(env, @native, "setRadius", "(F)V", , @card_radius)
       {% elsif flag?(:native_ios) %}
         LibIOS.card_view_set_radius(@native, @card_radius)
       {% end %}
@@ -109,8 +106,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         argb = (255 << 24) | ((color.r * 255).to_i << 16) | ((color.g * 255).to_i << 8) | (color.b * 255).to_i
-        set_bg = env.get_method_id(env.get_object_class(@native), "setCardBackgroundColor", "(I)V")
-        env.call_void_method(@native, set_bg, argb)
+        JNIHelpers.call_void(env, @native, "setCardBackgroundColor", "(I)V", , argb)
       {% elsif flag?(:native_ios) %}
         LibIOS.card_view_set_background_color(@native, color.r, color.g, color.b)
       {% end %}

--- a/src/native/framework/ui/card_view.cr
+++ b/src/native/framework/ui/card_view.cr
@@ -53,7 +53,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setContentPadding", "(IIII)V", , value, value, value, value)
+        JNIHelpers.call_void(env, @native, "setContentPadding", "(IIII)V", value, value, value, value)
       {% end %}
     end
 
@@ -65,7 +65,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0 && view.native_ptr != 0
-        JNIHelpers.call_void(env, @native, "addView", "(Landroid/view/View;)V", , view.native_ptr)
+        JNIHelpers.call_void(env, @native, "addView", "(Landroid/view/View;)V", view.native_ptr)
       {% elsif flag?(:native_ios) %}
         LibIOS.card_view_add_subview(@native, view.native_ptr)
       {% end %}
@@ -75,7 +75,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0 && view.native_ptr != 0
-        JNIHelpers.call_void(env, @native, "removeView", "(Landroid/view/View;)V", , view.native_ptr)
+        JNIHelpers.call_void(env, @native, "removeView", "(Landroid/view/View;)V", view.native_ptr)
       {% elsif flag?(:native_ios) %}
         LibIOS.card_view_remove_subview(@native, view.native_ptr)
       {% end %}
@@ -85,7 +85,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setCardElevation", "(F)V", , @card_elevation)
+        JNIHelpers.call_void(env, @native, "setCardElevation", "(F)V", @card_elevation)
       {% elsif flag?(:native_ios) %}
         LibIOS.card_view_set_elevation(@native, @card_elevation)
       {% end %}
@@ -95,7 +95,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setRadius", "(F)V", , @card_radius)
+        JNIHelpers.call_void(env, @native, "setRadius", "(F)V", @card_radius)
       {% elsif flag?(:native_ios) %}
         LibIOS.card_view_set_radius(@native, @card_radius)
       {% end %}
@@ -106,7 +106,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         argb = (255 << 24) | ((color.r * 255).to_i << 16) | ((color.g * 255).to_i << 8) | (color.b * 255).to_i
-        JNIHelpers.call_void(env, @native, "setCardBackgroundColor", "(I)V", , argb)
+        JNIHelpers.call_void(env, @native, "setCardBackgroundColor", "(I)V", argb)
       {% elsif flag?(:native_ios) %}
         LibIOS.card_view_set_background_color(@native, color.r, color.g, color.b)
       {% end %}

--- a/src/native/framework/ui/edit_text.cr
+++ b/src/native/framework/ui/edit_text.cr
@@ -48,7 +48,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         jtext = env.new_string_utf(value)
-        JNIHelpers.call_void(env, @native, "setText", "(Ljava/lang/CharSequence;)V", , jtext)
+        JNIHelpers.call_void(env, @native, "setText", "(Ljava/lang/CharSequence;)V", jtext)
         env.delete_local_ref(jtext) unless jtext.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.text_field_set_text(@native, value.to_utf8)
@@ -81,7 +81,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         jhint = env.new_string_utf(value)
-        JNIHelpers.call_void(env, @native, "setHint", "(Ljava/lang/CharSequence;)V", , jhint)
+        JNIHelpers.call_void(env, @native, "setHint", "(Ljava/lang/CharSequence;)V", jhint)
         env.delete_local_ref(jhint) unless jhint.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.text_field_set_placeholder(@native, value.to_utf8)
@@ -97,7 +97,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setTextSize", "(F)V", , value.to_f32)
+        JNIHelpers.call_void(env, @native, "setTextSize", "(F)V", value.to_f32)
       {% elsif flag?(:native_ios) %}
         LibIOS.text_field_set_text_size(@native, value)
       {% end %}
@@ -113,7 +113,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         color = ((value.a * 255).to_i << 24) | ((value.r * 255).to_i << 16) | ((value.g * 255).to_i << 8) | (value.b * 255).to_i
-        JNIHelpers.call_void(env, @native, "setTextColor", "(I)V", , color)
+        JNIHelpers.call_void(env, @native, "setTextColor", "(I)V", color)
       {% elsif flag?(:native_ios) %}
         LibIOS.text_field_set_text_color(@native, value.r, value.g, value.b)
       {% end %}
@@ -125,7 +125,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         color = ((value.a * 255).to_i << 24) | ((value.r * 255).to_i << 16) | ((value.g * 255).to_i << 8) | (value.b * 255).to_i
-        JNIHelpers.call_void(env, @native, "setHintTextColor", "(I)V", , color)
+        JNIHelpers.call_void(env, @native, "setHintTextColor", "(I)V", color)
       {% end %}
     end
 
@@ -134,7 +134,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setInputType", "(I)V", , type)
+        JNIHelpers.call_void(env, @native, "setInputType", "(I)V", type)
       {% elsif flag?(:native_ios) %}
         LibIOS.text_field_set_input_type(@native, type)
       {% end %}
@@ -170,7 +170,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setLines", "(I)V", , value)
+        JNIHelpers.call_void(env, @native, "setLines", "(I)V", value)
       {% end %}
     end
 
@@ -189,7 +189,7 @@ module Native::UI
         filter = env.new_object(filter_class, filter_constructor, value)
         env.delete_local_ref(filter_class) unless filter_class.null?
         env.set_object_array_element(filters, 0, filter)
-        JNIHelpers.call_void(env, @native, "setFilters", "([Landroid/text/InputFilter;)V", , filters)
+        JNIHelpers.call_void(env, @native, "setFilters", "([Landroid/text/InputFilter;)V", filters)
       {% end %}
     end
 
@@ -216,7 +216,7 @@ module Native::UI
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
       env.delete_local_ref(callback_class) unless callback_class.null?
 
-      JNIHelpers.call_void(env, @native, "addTextChangedListener", "(Landroid/text/TextWatcher;)V", , callback_obj)
+      JNIHelpers.call_void(env, @native, "addTextChangedListener", "(Landroid/text/TextWatcher;)V", callback_obj)
     end
 
     def handleTextChanged(text : String)

--- a/src/native/framework/ui/edit_text.cr
+++ b/src/native/framework/ui/edit_text.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/edit_text.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class EditText < View
@@ -24,6 +25,7 @@ module Native::UI
         view_class = env.find_class("android/widget/EditText")
         constructor = env.get_method_id(view_class, "<init>", "(Landroid/content/Context;)V")
         @native = env.new_object(view_class, constructor, activity).to_i64
+        env.delete_local_ref(view_class) unless view_class.null?
 
         if !text.empty?
           self.text = text
@@ -46,8 +48,8 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         jtext = env.new_string_utf(value)
-        set_text = env.get_method_id(env.get_object_class(@native), "setText", "(Ljava/lang/CharSequence;)V")
-        env.call_void_method(@native, set_text, jtext)
+        JNIHelpers.call_void(env, @native, "setText", "(Ljava/lang/CharSequence;)V", , jtext)
+        env.delete_local_ref(jtext) unless jtext.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.text_field_set_text(@native, value.to_utf8)
       {% end %}
@@ -79,8 +81,8 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         jhint = env.new_string_utf(value)
-        set_hint = env.get_method_id(env.get_object_class(@native), "setHint", "(Ljava/lang/CharSequence;)V")
-        env.call_void_method(@native, set_hint, jhint)
+        JNIHelpers.call_void(env, @native, "setHint", "(Ljava/lang/CharSequence;)V", , jhint)
+        env.delete_local_ref(jhint) unless jhint.null?
       {% elsif flag?(:native_ios) %}
         LibIOS.text_field_set_placeholder(@native, value.to_utf8)
       {% end %}
@@ -95,8 +97,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_size = env.get_method_id(env.get_object_class(@native), "setTextSize", "(F)V")
-        env.call_void_method(@native, set_size, value.to_f32)
+        JNIHelpers.call_void(env, @native, "setTextSize", "(F)V", , value.to_f32)
       {% elsif flag?(:native_ios) %}
         LibIOS.text_field_set_text_size(@native, value)
       {% end %}
@@ -112,8 +113,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         color = ((value.a * 255).to_i << 24) | ((value.r * 255).to_i << 16) | ((value.g * 255).to_i << 8) | (value.b * 255).to_i
-        set_color = env.get_method_id(env.get_object_class(@native), "setTextColor", "(I)V")
-        env.call_void_method(@native, set_color, color)
+        JNIHelpers.call_void(env, @native, "setTextColor", "(I)V", , color)
       {% elsif flag?(:native_ios) %}
         LibIOS.text_field_set_text_color(@native, value.r, value.g, value.b)
       {% end %}
@@ -125,8 +125,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         color = ((value.a * 255).to_i << 24) | ((value.r * 255).to_i << 16) | ((value.g * 255).to_i << 8) | (value.b * 255).to_i
-        set_hint_color = env.get_method_id(env.get_object_class(@native), "setHintTextColor", "(I)V")
-        env.call_void_method(@native, set_hint_color, color)
+        JNIHelpers.call_void(env, @native, "setHintTextColor", "(I)V", , color)
       {% end %}
     end
 
@@ -135,8 +134,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_input = env.get_method_id(env.get_object_class(@native), "setInputType", "(I)V")
-        env.call_void_method(@native, set_input, type)
+        JNIHelpers.call_void(env, @native, "setInputType", "(I)V", , type)
       {% elsif flag?(:native_ios) %}
         LibIOS.text_field_set_input_type(@native, type)
       {% end %}
@@ -172,8 +170,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_lines = env.get_method_id(env.get_object_class(@native), "setLines", "(I)V")
-        env.call_void_method(@native, set_lines, value)
+        JNIHelpers.call_void(env, @native, "setLines", "(I)V", , value)
       {% end %}
     end
 
@@ -190,9 +187,9 @@ module Native::UI
         filter_class = env.find_class("android/text/InputFilter$LengthFilter")
         filter_constructor = env.get_method_id(filter_class, "<init>", "(I)V")
         filter = env.new_object(filter_class, filter_constructor, value)
+        env.delete_local_ref(filter_class) unless filter_class.null?
         env.set_object_array_element(filters, 0, filter)
-        set_filters = env.get_method_id(env.get_object_class(@native), "setFilters", "([Landroid/text/InputFilter;)V")
-        env.call_void_method(@native, set_filters, filters)
+        JNIHelpers.call_void(env, @native, "setFilters", "([Landroid/text/InputFilter;)V", , filters)
       {% end %}
     end
 
@@ -217,9 +214,9 @@ module Native::UI
       end
 
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
+      env.delete_local_ref(callback_class) unless callback_class.null?
 
-      add_watcher = env.get_method_id(env.get_object_class(@native), "addTextChangedListener", "(Landroid/text/TextWatcher;)V")
-      env.call_void_method(@native, add_watcher, callback_obj)
+      JNIHelpers.call_void(env, @native, "addTextChangedListener", "(Landroid/text/TextWatcher;)V", , callback_obj)
     end
 
     def handleTextChanged(text : String)

--- a/src/native/framework/ui/icon.cr
+++ b/src/native/framework/ui/icon.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/icon.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class Icon < TextView
@@ -49,6 +50,7 @@ module Native::UI
 
         asset_manager = env.call_object_method(Native::Android::JNI.activity, env.get_method_id(env.get_object_class(Native::Android::JNI.activity), "getAssets", "()Landroid/content/res/AssetManager;"))
         typeface = env.call_static_object_method(typeface_class, create_method, asset_manager, env.new_string_utf("#{@font_family}.ttf"))
+        env.delete_local_ref(typeface_class) unless typeface_class.null?
 
         if typeface
           env.call_void_method(@native, set_typeface, typeface)

--- a/src/native/framework/ui/image_view.cr
+++ b/src/native/framework/ui/image_view.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/image_view.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class ImageView < View
@@ -23,6 +24,7 @@ module Native::UI
         image_class = env.find_class("android/widget/ImageView")
         constructor = env.get_method_id(image_class, "<init>", "(Landroid/content/Context;)V")
         @native = env.new_object(image_class, constructor, activity).to_i64
+        env.delete_local_ref(image_class) unless image_class.null?
       {% elsif flag?(:native_ios) %}
         ptr = LibIOS.create_image_view
         @native = ptr.to_i64
@@ -33,8 +35,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_image = env.get_method_id(env.get_object_class(@native), "setImageResource", "(I)V")
-        env.call_void_method(@native, set_image, resource_id)
+        JNIHelpers.call_void(env, @native, "setImageResource", "(I)V", resource_id)
       {% elsif flag?(:native_ios) %}
         LibIOS.image_view_set_resource(@native, resource_id)
       {% end %}
@@ -49,6 +50,8 @@ module Native::UI
         uri_class = env.find_class("android/net/Uri")
         parse_method = env.get_static_method_id(uri_class, "parse", "(Ljava/lang/String;)Landroid/net/Uri;")
         uri = env.call_static_object_method(uri_class, parse_method, jpath)
+        env.delete_local_ref(jpath) unless jpath.null?
+        env.delete_local_ref(uri_class) unless uri_class.null?
         env.call_void_method(@native, set_image, uri)
       {% elsif flag?(:native_ios) %}
         LibIOS.image_view_set_path(@native, path.to_utf8)
@@ -65,6 +68,7 @@ module Native::UI
         bitmap_class = env.find_class("android/graphics/BitmapFactory")
         decode_method = env.get_static_method_id(bitmap_class, "decodeByteArray", "([BII)Landroid/graphics/Bitmap;")
         bitmap = env.call_static_object_method(bitmap_class, decode_method, byte_array, 0, data.size)
+        env.delete_local_ref(bitmap_class) unless bitmap_class.null?
         env.call_void_method(@native, set_image, bitmap)
       {% elsif flag?(:native_ios) %}
         LibIOS.image_view_set_data(@native, data, data.size)
@@ -86,8 +90,7 @@ module Native::UI
                       end
         scale_field = env.get_static_field_id(env.find_class("android/widget/ImageView$ScaleType"), scale_value, "Landroid/widget/ImageView$ScaleType;")
         scale_obj = env.get_static_object_field(env.find_class("android/widget/ImageView$ScaleType"), scale_field)
-        set_scale = env.get_method_id(env.get_object_class(@native), "setScaleType", "(Landroid/widget/ImageView$ScaleType;)V")
-        env.call_void_method(@native, set_scale, scale_obj)
+        JNIHelpers.call_void(env, @native, "setScaleType", "(Landroid/widget/ImageView$ScaleType;)V", , scale_obj)
       {% elsif flag?(:native_ios) %}
         scale_value = type.value
         LibIOS.image_view_set_scale_type(@native, scale_value)
@@ -121,8 +124,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_alpha = env.get_method_id(env.get_object_class(@native), "setAlpha", "(F)V")
-        env.call_void_method(@native, set_alpha, value)
+        JNIHelpers.call_void(env, @native, "setAlpha", "(F)V", , value)
       {% elsif flag?(:native_ios) %}
         LibIOS.image_view_set_alpha(@native, value)
       {% end %}
@@ -132,8 +134,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return 1.0f32 unless env && @native != 0
-        get_alpha = env.get_method_id(env.get_object_class(@native), "getAlpha", "()F")
-        env.call_float_method(@native, get_alpha)
+        JNIHelpers.call_float(env, @native, "getAlpha", "()F")
       {% else %}
         1.0f32
       {% end %}

--- a/src/native/framework/ui/image_view.cr
+++ b/src/native/framework/ui/image_view.cr
@@ -90,7 +90,7 @@ module Native::UI
                       end
         scale_field = env.get_static_field_id(env.find_class("android/widget/ImageView$ScaleType"), scale_value, "Landroid/widget/ImageView$ScaleType;")
         scale_obj = env.get_static_object_field(env.find_class("android/widget/ImageView$ScaleType"), scale_field)
-        JNIHelpers.call_void(env, @native, "setScaleType", "(Landroid/widget/ImageView$ScaleType;)V", , scale_obj)
+        JNIHelpers.call_void(env, @native, "setScaleType", "(Landroid/widget/ImageView$ScaleType;)V", scale_obj)
       {% elsif flag?(:native_ios) %}
         scale_value = type.value
         LibIOS.image_view_set_scale_type(@native, scale_value)
@@ -124,7 +124,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setAlpha", "(F)V", , value)
+        JNIHelpers.call_void(env, @native, "setAlpha", "(F)V", value)
       {% elsif flag?(:native_ios) %}
         LibIOS.image_view_set_alpha(@native, value)
       {% end %}

--- a/src/native/framework/ui/recycler_view.cr
+++ b/src/native/framework/ui/recycler_view.cr
@@ -151,7 +151,7 @@ module Native::UI
         adapter_obj = env.call_object_method(@native, get_adapter)
 
         if adapter_obj
-          JNIHelpers.call_void(env, adapter_obj, "notifyDataSetChanged", "()V")
+          JNIHelpers.call_void(env, adapter_obj.to_i64, "notifyDataSetChanged", "()V")
         end
       {% elsif flag?(:native_ios) %}
         LibIOS.table_view_reload_data(@native)
@@ -167,7 +167,7 @@ module Native::UI
         adapter_obj = env.call_object_method(@native, get_adapter)
 
         if adapter_obj
-          JNIHelpers.call_void(env, adapter_obj, "notifyItemInserted", "(I)V", position)
+          JNIHelpers.call_void(env, adapter_obj.to_i64, "notifyItemInserted", "(I)V", position)
         end
       {% end %}
     end
@@ -181,7 +181,7 @@ module Native::UI
         adapter_obj = env.call_object_method(@native, get_adapter)
 
         if adapter_obj
-          JNIHelpers.call_void(env, adapter_obj, "notifyItemRemoved", "(I)V", position)
+          JNIHelpers.call_void(env, adapter_obj.to_i64, "notifyItemRemoved", "(I)V", position)
         end
       {% end %}
     end

--- a/src/native/framework/ui/recycler_view.cr
+++ b/src/native/framework/ui/recycler_view.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/recycler_view.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   abstract class RecyclerViewAdapter
@@ -40,6 +41,7 @@ module Native::UI
         rv_class = env.find_class("androidx/recyclerview/widget/RecyclerView")
         constructor = env.get_method_id(rv_class, "<init>", "(Landroid/content/Context;)V")
         @native = env.new_object(rv_class, constructor, activity).to_i64
+        env.delete_local_ref(rv_class) unless rv_class.null?
 
         set_layout_manager(LayoutManager::Linear)
       {% elsif flag?(:native_ios) %}
@@ -61,9 +63,9 @@ module Native::UI
         end
 
         adapter_obj = env.new_object(rv_adapter_class, env.get_method_id(rv_adapter_class, "<init>", "(J)V"), 0i64)
+        env.delete_local_ref(rv_adapter_class) unless rv_adapter_class.null?
 
-        set_adapter = env.get_method_id(env.get_object_class(@native), "setAdapter", "(Landroidx/recyclerview/widget/RecyclerView$Adapter;)V")
-        env.call_void_method(@native, set_adapter, adapter_obj)
+        JNIHelpers.call_void(env, @native, "setAdapter", "(Landroidx/recyclerview/widget/RecyclerView$Adapter;)V", , adapter_obj)
       {% elsif flag?(:native_ios) %}
         LibIOS.table_view_set_delegate(@native, 0i64)
       {% end %}
@@ -107,8 +109,7 @@ module Native::UI
           lm = env.new_object(lm_class, constructor, 2, 1)
         end
 
-        set_lm = env.get_method_id(env.get_object_class(@native), "setLayoutManager", "(Landroidx/recyclerview/widget/RecyclerView$LayoutManager;)V")
-        env.call_void_method(@native, set_lm, lm)
+        JNIHelpers.call_void(env, @native, "setLayoutManager", "(Landroidx/recyclerview/widget/RecyclerView$LayoutManager;)V", , lm)
       {% elsif flag?(:native_ios) %}
         LibIOS.table_view_set_style(@native, manager.value)
       {% end %}
@@ -128,11 +129,9 @@ module Native::UI
         return unless env && @native != 0
 
         if smooth
-          smooth_scroll = env.get_method_id(env.get_object_class(@native), "smoothScrollToPosition", "(I)V")
-          env.call_void_method(@native, smooth_scroll, position)
+          JNIHelpers.call_void(env, @native, "smoothScrollToPosition", "(I)V", , position)
         else
-          scroll_to = env.get_method_id(env.get_object_class(@native), "scrollToPosition", "(I)V")
-          env.call_void_method(@native, scroll_to, position)
+          JNIHelpers.call_void(env, @native, "scrollToPosition", "(I)V", , position)
         end
       {% elsif flag?(:native_ios) %}
         LibIOS.table_view_scroll_to_row(@native, position, smooth)
@@ -152,8 +151,7 @@ module Native::UI
         adapter_obj = env.call_object_method(@native, get_adapter)
 
         if adapter_obj
-          notify_changed = env.get_method_id(env.get_object_class(adapter_obj), "notifyDataSetChanged", "()V")
-          env.call_void_method(adapter_obj, notify_changed)
+          JNIHelpers.call_void(env, adapter_obj, "notifyDataSetChanged", "()V")
         end
       {% elsif flag?(:native_ios) %}
         LibIOS.table_view_reload_data(@native)
@@ -169,8 +167,7 @@ module Native::UI
         adapter_obj = env.call_object_method(@native, get_adapter)
 
         if adapter_obj
-          notify_insert = env.get_method_id(env.get_object_class(adapter_obj), "notifyItemInserted", "(I)V")
-          env.call_void_method(adapter_obj, notify_insert, position)
+          JNIHelpers.call_void(env, adapter_obj, "notifyItemInserted", "(I)V", , position)
         end
       {% end %}
     end
@@ -184,8 +181,7 @@ module Native::UI
         adapter_obj = env.call_object_method(@native, get_adapter)
 
         if adapter_obj
-          notify_remove = env.get_method_id(env.get_object_class(adapter_obj), "notifyItemRemoved", "(I)V")
-          env.call_void_method(adapter_obj, notify_remove, position)
+          JNIHelpers.call_void(env, adapter_obj, "notifyItemRemoved", "(I)V", , position)
         end
       {% end %}
     end

--- a/src/native/framework/ui/recycler_view.cr
+++ b/src/native/framework/ui/recycler_view.cr
@@ -65,7 +65,7 @@ module Native::UI
         adapter_obj = env.new_object(rv_adapter_class, env.get_method_id(rv_adapter_class, "<init>", "(J)V"), 0i64)
         env.delete_local_ref(rv_adapter_class) unless rv_adapter_class.null?
 
-        JNIHelpers.call_void(env, @native, "setAdapter", "(Landroidx/recyclerview/widget/RecyclerView$Adapter;)V", , adapter_obj)
+        JNIHelpers.call_void(env, @native, "setAdapter", "(Landroidx/recyclerview/widget/RecyclerView$Adapter;)V", adapter_obj)
       {% elsif flag?(:native_ios) %}
         LibIOS.table_view_set_delegate(@native, 0i64)
       {% end %}
@@ -109,7 +109,7 @@ module Native::UI
           lm = env.new_object(lm_class, constructor, 2, 1)
         end
 
-        JNIHelpers.call_void(env, @native, "setLayoutManager", "(Landroidx/recyclerview/widget/RecyclerView$LayoutManager;)V", , lm)
+        JNIHelpers.call_void(env, @native, "setLayoutManager", "(Landroidx/recyclerview/widget/RecyclerView$LayoutManager;)V", lm)
       {% elsif flag?(:native_ios) %}
         LibIOS.table_view_set_style(@native, manager.value)
       {% end %}
@@ -129,9 +129,9 @@ module Native::UI
         return unless env && @native != 0
 
         if smooth
-          JNIHelpers.call_void(env, @native, "smoothScrollToPosition", "(I)V", , position)
+          JNIHelpers.call_void(env, @native, "smoothScrollToPosition", "(I)V", position)
         else
-          JNIHelpers.call_void(env, @native, "scrollToPosition", "(I)V", , position)
+          JNIHelpers.call_void(env, @native, "scrollToPosition", "(I)V", position)
         end
       {% elsif flag?(:native_ios) %}
         LibIOS.table_view_scroll_to_row(@native, position, smooth)
@@ -167,7 +167,7 @@ module Native::UI
         adapter_obj = env.call_object_method(@native, get_adapter)
 
         if adapter_obj
-          JNIHelpers.call_void(env, adapter_obj, "notifyItemInserted", "(I)V", , position)
+          JNIHelpers.call_void(env, adapter_obj, "notifyItemInserted", "(I)V", position)
         end
       {% end %}
     end
@@ -181,7 +181,7 @@ module Native::UI
         adapter_obj = env.call_object_method(@native, get_adapter)
 
         if adapter_obj
-          JNIHelpers.call_void(env, adapter_obj, "notifyItemRemoved", "(I)V", , position)
+          JNIHelpers.call_void(env, adapter_obj, "notifyItemRemoved", "(I)V", position)
         end
       {% end %}
     end

--- a/src/native/framework/ui/scroll_view.cr
+++ b/src/native/framework/ui/scroll_view.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/scroll_view.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class ScrollView < View
@@ -37,6 +38,7 @@ module Native::UI
 
         constructor = env.get_method_id(scroll_class, "<init>", "(Landroid/content/Context;)V")
         @native = env.new_object(scroll_class, constructor, activity).to_i64
+        env.delete_local_ref(scroll_class) unless scroll_class.null?
 
         setupScrollListener
       {% elsif flag?(:native_ios) %}
@@ -50,8 +52,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0 && view.native_ptr != 0
-        add_view = env.get_method_id(env.get_object_class(@native), "addView", "(Landroid/view/View;)V")
-        env.call_void_method(@native, add_view, view.native_ptr)
+        JNIHelpers.call_void(env, @native, "addView", "(Landroid/view/View;)V", , view.native_ptr)
       {% elsif flag?(:native_ios) %}
         LibIOS.scroll_view_add_view(@native, view.native_ptr)
       {% end %}
@@ -61,8 +62,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0 && view.native_ptr != 0
-        remove_view = env.get_method_id(env.get_object_class(@native), "removeView", "(Landroid/view/View;)V")
-        env.call_void_method(@native, remove_view, view.native_ptr)
+        JNIHelpers.call_void(env, @native, "removeView", "(Landroid/view/View;)V", , view.native_ptr)
       {% elsif flag?(:native_ios) %}
         LibIOS.scroll_view_remove_view(@native, view.native_ptr)
       {% end %}
@@ -74,11 +74,9 @@ module Native::UI
         return unless env && @native != 0
 
         if animated
-          smooth_scroll = env.get_method_id(env.get_object_class(@native), "smoothScrollTo", "(II)V")
-          env.call_void_method(@native, smooth_scroll, x, y)
+          JNIHelpers.call_void(env, @native, "smoothScrollTo", "(II)V", , x, y)
         else
-          scroll_to = env.get_method_id(env.get_object_class(@native), "scrollTo", "(II)V")
-          env.call_void_method(@native, scroll_to, x, y)
+          JNIHelpers.call_void(env, @native, "scrollTo", "(II)V", x, y)
         end
       {% elsif flag?(:native_ios) %}
         LibIOS.scroll_view_scroll_to(@native, x, y, animated)
@@ -108,8 +106,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return 0 unless env && @native != 0
-        get_x = env.get_method_id(env.get_object_class(@native), "getScrollX", "()I")
-        env.call_int_method(@native, get_x)
+        JNIHelpers.call_int(env, @native, "getScrollX", "()I")
       {% elsif flag?(:native_ios) %}
         LibIOS.scroll_view_get_scroll_x(@native)
       {% else %}
@@ -121,8 +118,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return 0 unless env && @native != 0
-        get_y = env.get_method_id(env.get_object_class(@native), "getScrollY", "()I")
-        env.call_int_method(@native, get_y)
+        JNIHelpers.call_int(env, @native, "getScrollY", "()I")
       {% elsif flag?(:native_ios) %}
         LibIOS.scroll_view_get_scroll_y(@native)
       {% else %}
@@ -157,8 +153,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_style = env.get_method_id(env.get_object_class(@native), "setScrollBarStyle", "(I)V")
-        env.call_void_method(@native, set_style, value.value)
+        JNIHelpers.call_void(env, @native, "setScrollBarStyle", "(I)V", , value.value)
       {% end %}
     end
 
@@ -209,9 +204,9 @@ module Native::UI
       end
 
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
+      env.delete_local_ref(callback_class) unless callback_class.null?
 
-      set_listener = env.get_method_id(env.get_object_class(@native), "setOnScrollChangeListener", "(Landroid/view/View$OnScrollChangeListener;)V")
-      env.call_void_method(@native, set_listener, callback_obj)
+      JNIHelpers.call_void(env, @native, "setOnScrollChangeListener", "(Landroid/view/View$OnScrollChangeListener;)V", , callback_obj)
     end
 
     def handleScrollChanged(x : Int32, y : Int32)

--- a/src/native/framework/ui/scroll_view.cr
+++ b/src/native/framework/ui/scroll_view.cr
@@ -52,7 +52,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0 && view.native_ptr != 0
-        JNIHelpers.call_void(env, @native, "addView", "(Landroid/view/View;)V", , view.native_ptr)
+        JNIHelpers.call_void(env, @native, "addView", "(Landroid/view/View;)V", view.native_ptr)
       {% elsif flag?(:native_ios) %}
         LibIOS.scroll_view_add_view(@native, view.native_ptr)
       {% end %}
@@ -62,7 +62,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0 && view.native_ptr != 0
-        JNIHelpers.call_void(env, @native, "removeView", "(Landroid/view/View;)V", , view.native_ptr)
+        JNIHelpers.call_void(env, @native, "removeView", "(Landroid/view/View;)V", view.native_ptr)
       {% elsif flag?(:native_ios) %}
         LibIOS.scroll_view_remove_view(@native, view.native_ptr)
       {% end %}
@@ -74,7 +74,7 @@ module Native::UI
         return unless env && @native != 0
 
         if animated
-          JNIHelpers.call_void(env, @native, "smoothScrollTo", "(II)V", , x, y)
+          JNIHelpers.call_void(env, @native, "smoothScrollTo", "(II)V", x, y)
         else
           JNIHelpers.call_void(env, @native, "scrollTo", "(II)V", x, y)
         end
@@ -153,7 +153,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setScrollBarStyle", "(I)V", , value.value)
+        JNIHelpers.call_void(env, @native, "setScrollBarStyle", "(I)V", value.value)
       {% end %}
     end
 
@@ -206,7 +206,7 @@ module Native::UI
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
       env.delete_local_ref(callback_class) unless callback_class.null?
 
-      JNIHelpers.call_void(env, @native, "setOnScrollChangeListener", "(Landroid/view/View$OnScrollChangeListener;)V", , callback_obj)
+      JNIHelpers.call_void(env, @native, "setOnScrollChangeListener", "(Landroid/view/View$OnScrollChangeListener;)V", callback_obj)
     end
 
     def handleScrollChanged(x : Int32, y : Int32)

--- a/src/native/framework/ui/spinner.cr
+++ b/src/native/framework/ui/spinner.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/spinner.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class Spinner < View
@@ -19,6 +20,7 @@ module Native::UI
         spinner_class = env.find_class("android/widget/Spinner")
         constructor = env.get_method_id(spinner_class, "<init>", "(Landroid/content/Context;)V")
         @native = env.new_object(spinner_class, constructor, activity).to_i64
+        env.delete_local_ref(spinner_class) unless spinner_class.null?
 
         setupSpinnerListener
       {% elsif flag?(:native_ios) %}
@@ -38,6 +40,7 @@ module Native::UI
         array_list = env.new_object(array_class, array_constructor)
 
         add_method = env.get_method_id(array_class, "add", "(Ljava/lang/Object;)Z")
+        env.delete_local_ref(array_class) unless array_class.null?
 
         items.each do |item|
           env.call_boolean_method(array_list, add_method, env.new_string_utf(item))
@@ -50,9 +53,9 @@ module Native::UI
         layout_id = env.get_static_int_field(env.find_class("android/R$layout"), layout)
 
         adapter = env.new_object(adapter_class, adapter_constructor, Native::Android::JNI.activity, layout_id, array_list)
+        env.delete_local_ref(adapter_class) unless adapter_class.null?
 
-        set_adapter = env.get_method_id(env.get_object_class(@native), "setAdapter", "(Landroid/widget/SpinnerAdapter;)V")
-        env.call_void_method(@native, set_adapter, adapter)
+        JNIHelpers.call_void(env, @native, "setAdapter", "(Landroid/widget/SpinnerAdapter;)V", , adapter)
       {% elsif flag?(:native_ios) %}
         LibIOS.picker_view_set_items(@native, items.to_utf8)
       {% end %}
@@ -67,8 +70,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_selection = env.get_method_id(env.get_object_class(@native), "setSelection", "(I)V")
-        env.call_void_method(@native, set_selection, @selected_position)
+        JNIHelpers.call_void(env, @native, "setSelection", "(I)V", , @selected_position)
       {% elsif flag?(:native_ios) %}
         LibIOS.picker_view_set_selected(@native, @selected_position)
       {% end %}
@@ -96,8 +98,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_prompt = env.get_method_id(env.get_object_class(@native), "setPrompt", "(Ljava/lang/CharSequence;)V")
-        env.call_void_method(@native, set_prompt, env.new_string_utf(value))
+        JNIHelpers.call_void(env, @native, "setPrompt", "(Ljava/lang/CharSequence;)V", , env.new_string_utf(value))
       {% end %}
     end
 
@@ -110,8 +111,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        set_width = env.get_method_id(env.get_object_class(@native), "setDropDownWidth", "(I)V")
-        env.call_void_method(@native, set_width, width)
+        JNIHelpers.call_void(env, @native, "setDropDownWidth", "(I)V", , width)
       {% end %}
     end
 
@@ -136,9 +136,9 @@ module Native::UI
       end
 
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
+      env.delete_local_ref(callback_class) unless callback_class.null?
 
-      set_listener = env.get_method_id(env.get_object_class(@native), "setOnItemSelectedListener", "(Landroid/widget/AdapterView$OnItemSelectedListener;)V")
-      env.call_void_method(@native, set_listener, callback_obj)
+      JNIHelpers.call_void(env, @native, "setOnItemSelectedListener", "(Landroid/widget/AdapterView$OnItemSelectedListener;)V", , callback_obj)
     end
 
     def handleItemSelected(position : Int32)

--- a/src/native/framework/ui/spinner.cr
+++ b/src/native/framework/ui/spinner.cr
@@ -55,7 +55,7 @@ module Native::UI
         adapter = env.new_object(adapter_class, adapter_constructor, Native::Android::JNI.activity, layout_id, array_list)
         env.delete_local_ref(adapter_class) unless adapter_class.null?
 
-        JNIHelpers.call_void(env, @native, "setAdapter", "(Landroid/widget/SpinnerAdapter;)V", , adapter)
+        JNIHelpers.call_void(env, @native, "setAdapter", "(Landroid/widget/SpinnerAdapter;)V", adapter)
       {% elsif flag?(:native_ios) %}
         LibIOS.picker_view_set_items(@native, items.to_utf8)
       {% end %}
@@ -70,7 +70,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setSelection", "(I)V", , @selected_position)
+        JNIHelpers.call_void(env, @native, "setSelection", "(I)V", @selected_position)
       {% elsif flag?(:native_ios) %}
         LibIOS.picker_view_set_selected(@native, @selected_position)
       {% end %}
@@ -98,7 +98,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setPrompt", "(Ljava/lang/CharSequence;)V", , env.new_string_utf(value))
+        JNIHelpers.call_void_string(env, @native, "setPrompt", "(Ljava/lang/CharSequence;)V", value)
       {% end %}
     end
 
@@ -111,7 +111,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "setDropDownWidth", "(I)V", , width)
+        JNIHelpers.call_void(env, @native, "setDropDownWidth", "(I)V", width)
       {% end %}
     end
 
@@ -138,7 +138,7 @@ module Native::UI
       callback_obj = env.new_object(callback_class, env.get_method_id(callback_class, "<init>", "(J)V"), 0i64)
       env.delete_local_ref(callback_class) unless callback_class.null?
 
-      JNIHelpers.call_void(env, @native, "setOnItemSelectedListener", "(Landroid/widget/AdapterView$OnItemSelectedListener;)V", , callback_obj)
+      JNIHelpers.call_void(env, @native, "setOnItemSelectedListener", "(Landroid/widget/AdapterView$OnItemSelectedListener;)V", callback_obj)
     end
 
     def handleItemSelected(position : Int32)

--- a/src/native/framework/ui/web_view.cr
+++ b/src/native/framework/ui/web_view.cr
@@ -1,4 +1,5 @@
 # src/native/framework/ui/web_view.cr
+# Refactored to use JNIHelpers for automatic local reference cleanup.
 
 module Native::UI
   class WebView < View
@@ -20,6 +21,7 @@ module Native::UI
         webview_class = env.find_class("android/webkit/WebView")
         constructor = env.get_method_id(webview_class, "<init>", "(Landroid/content/Context;)V")
         @native = env.new_object(webview_class, constructor, activity).to_i64
+        env.delete_local_ref(webview_class) unless webview_class.null?
 
         setupWebView
         setupWebViewClient
@@ -35,8 +37,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        load_url = env.get_method_id(env.get_object_class(@native), "loadUrl", "(Ljava/lang/String;)V")
-        env.call_void_method(@native, load_url, env.new_string_utf(value))
+        JNIHelpers.call_void(env, @native, "loadUrl", "(Ljava/lang/String;)V", , env.new_string_utf(value))
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_load_url(@native, value.to_utf8)
       {% end %}
@@ -50,8 +51,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        load_data = env.get_method_id(env.get_object_class(@native), "loadDataWithBaseURL", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V")
-        env.call_void_method(@native, load_data, env.new_string_utf(base_url), env.new_string_utf(html), env.new_string_utf("text/html"), env.new_string_utf("UTF-8"), env.new_string_utf(""))
+        JNIHelpers.call_void(env, @native, "loadDataWithBaseURL", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V", , env.new_string_utf(base_url), env.new_string_utf(html), env.new_string_utf("text/html"), env.new_string_utf("UTF-8"), env.new_string_utf(""))
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_load_html(@native, html.to_utf8, base_url.to_utf8)
       {% end %}
@@ -63,8 +63,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         settings = env.call_object_method(@native, env.get_method_id(env.get_object_class(@native), "getSettings", "()Landroid/webkit/WebSettings;"))
-        set_js = env.get_method_id(env.get_object_class(settings), "setJavaScriptEnabled", "(Z)V")
-        env.call_void_method(settings, set_js, value)
+        JNIHelpers.call_void(env, settings, "setJavaScriptEnabled", "(Z)V", , value)
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_set_js_enabled(@native, value)
       {% end %}
@@ -80,8 +79,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         settings = env.call_object_method(@native, env.get_method_id(env.get_object_class(@native), "getSettings", "()Landroid/webkit/WebSettings;"))
-        set_dom = env.get_method_id(env.get_object_class(settings), "setDomStorageEnabled", "(Z)V")
-        env.call_void_method(settings, set_dom, value)
+        JNIHelpers.call_void(env, settings, "setDomStorageEnabled", "(Z)V", , value)
       {% end %}
     end
 
@@ -93,8 +91,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return false unless env && @native != 0
-        can_go = env.get_method_id(env.get_object_class(@native), "canGoBack", "()Z")
-        env.call_boolean_method(@native, can_go)
+        JNIHelpers.call_boolean(env, @native, "canGoBack", "()Z")
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_can_go_back(@native)
       {% else %}
@@ -106,8 +103,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return false unless env && @native != 0
-        can_go = env.get_method_id(env.get_object_class(@native), "canGoForward", "()Z")
-        env.call_boolean_method(@native, can_go)
+        JNIHelpers.call_boolean(env, @native, "canGoForward", "()Z")
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_can_go_forward(@native)
       {% else %}
@@ -119,8 +115,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        go = env.get_method_id(env.get_object_class(@native), "goBack", "()V")
-        env.call_void_method(@native, go)
+        JNIHelpers.call_void(env, @native, "goBack", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_go_back(@native)
       {% end %}
@@ -130,8 +125,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        go = env.get_method_id(env.get_object_class(@native), "goForward", "()V")
-        env.call_void_method(@native, go)
+        JNIHelpers.call_void(env, @native, "goForward", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_go_forward(@native)
       {% end %}
@@ -141,8 +135,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        reload = env.get_method_id(env.get_object_class(@native), "reload", "()V")
-        env.call_void_method(@native, reload)
+        JNIHelpers.call_void(env, @native, "reload", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_reload(@native)
       {% end %}
@@ -152,8 +145,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        stop = env.get_method_id(env.get_object_class(@native), "stopLoading", "()V")
-        env.call_void_method(@native, stop)
+        JNIHelpers.call_void(env, @native, "stopLoading", "()V")
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_stop_loading(@native)
       {% end %}
@@ -179,8 +171,7 @@ module Native::UI
       return unless env && @native != 0
 
       settings = env.call_object_method(@native, env.get_method_id(env.get_object_class(@native), "getSettings", "()Landroid/webkit/WebSettings;"))
-      set_cache = env.get_method_id(env.get_object_class(settings), "setCacheMode", "(I)V")
-      env.call_void_method(settings, set_cache, -1)
+      JNIHelpers.call_void(env, settings, "setCacheMode", "(I)V", , -1)
     end
 
     private def setupWebViewClient
@@ -196,9 +187,9 @@ module Native::UI
       end
 
       client_obj = env.new_object(client_class, env.get_method_id(client_class, "<init>", "(J)V"), 0i64)
+      env.delete_local_ref(client_class) unless client_class.null?
 
-      set_client = env.get_method_id(env.get_object_class(@native), "setWebViewClient", "(Landroid/webkit/WebViewClient;)V")
-      env.call_void_method(@native, set_client, client_obj)
+      JNIHelpers.call_void(env, @native, "setWebViewClient", "(Landroid/webkit/WebViewClient;)V", , client_obj)
     end
 
     private def setupWebChromeClient
@@ -214,9 +205,9 @@ module Native::UI
       end
 
       chrome_obj = env.new_object(chrome_class, env.get_method_id(chrome_class, "<init>", "(J)V"), 0i64)
+      env.delete_local_ref(chrome_class) unless chrome_class.null?
 
-      set_chrome = env.get_method_id(env.get_object_class(@native), "setWebChromeClient", "(Landroid/webkit/WebChromeClient;)V")
-      env.call_void_method(@native, set_chrome, chrome_obj)
+      JNIHelpers.call_void(env, @native, "setWebChromeClient", "(Landroid/webkit/WebChromeClient;)V", , chrome_obj)
     end
 
     def handlePageStarted(url : String)

--- a/src/native/framework/ui/web_view.cr
+++ b/src/native/framework/ui/web_view.cr
@@ -37,7 +37,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "loadUrl", "(Ljava/lang/String;)V", , env.new_string_utf(value))
+        JNIHelpers.call_void_string(env, @native, "loadUrl", "(Ljava/lang/String;)V", value)
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_load_url(@native, value.to_utf8)
       {% end %}
@@ -51,7 +51,7 @@ module Native::UI
       {% if flag?(:native_android) %}
         env = Native::Android::JNI.env
         return unless env && @native != 0
-        JNIHelpers.call_void(env, @native, "loadDataWithBaseURL", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V", , env.new_string_utf(base_url), env.new_string_utf(html), env.new_string_utf("text/html"), env.new_string_utf("UTF-8"), env.new_string_utf(""))
+        JNIHelpers.call_void_string(env, @native, "loadDataWithBaseURL", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V", env.new_string_utf(base_url), env.new_string_utf(html), env.new_string_utf("text/html"), env.new_string_utf("UTF-8"), "")
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_load_html(@native, html.to_utf8, base_url.to_utf8)
       {% end %}
@@ -63,7 +63,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         settings = env.call_object_method(@native, env.get_method_id(env.get_object_class(@native), "getSettings", "()Landroid/webkit/WebSettings;"))
-        JNIHelpers.call_void(env, settings, "setJavaScriptEnabled", "(Z)V", , value)
+        JNIHelpers.call_void(env, settings, "setJavaScriptEnabled", "(Z)V", value)
       {% elsif flag?(:native_ios) %}
         LibIOS.web_view_set_js_enabled(@native, value)
       {% end %}
@@ -79,7 +79,7 @@ module Native::UI
         env = Native::Android::JNI.env
         return unless env && @native != 0
         settings = env.call_object_method(@native, env.get_method_id(env.get_object_class(@native), "getSettings", "()Landroid/webkit/WebSettings;"))
-        JNIHelpers.call_void(env, settings, "setDomStorageEnabled", "(Z)V", , value)
+        JNIHelpers.call_void(env, settings, "setDomStorageEnabled", "(Z)V", value)
       {% end %}
     end
 
@@ -171,7 +171,7 @@ module Native::UI
       return unless env && @native != 0
 
       settings = env.call_object_method(@native, env.get_method_id(env.get_object_class(@native), "getSettings", "()Landroid/webkit/WebSettings;"))
-      JNIHelpers.call_void(env, settings, "setCacheMode", "(I)V", , -1)
+      JNIHelpers.call_void(env, settings, "setCacheMode", "(I)V", -1)
     end
 
     private def setupWebViewClient
@@ -189,7 +189,7 @@ module Native::UI
       client_obj = env.new_object(client_class, env.get_method_id(client_class, "<init>", "(J)V"), 0i64)
       env.delete_local_ref(client_class) unless client_class.null?
 
-      JNIHelpers.call_void(env, @native, "setWebViewClient", "(Landroid/webkit/WebViewClient;)V", , client_obj)
+      JNIHelpers.call_void(env, @native, "setWebViewClient", "(Landroid/webkit/WebViewClient;)V", client_obj)
     end
 
     private def setupWebChromeClient
@@ -207,7 +207,7 @@ module Native::UI
       chrome_obj = env.new_object(chrome_class, env.get_method_id(chrome_class, "<init>", "(J)V"), 0i64)
       env.delete_local_ref(chrome_class) unless chrome_class.null?
 
-      JNIHelpers.call_void(env, @native, "setWebChromeClient", "(Landroid/webkit/WebChromeClient;)V", , chrome_obj)
+      JNIHelpers.call_void(env, @native, "setWebChromeClient", "(Landroid/webkit/WebChromeClient;)V", chrome_obj)
     end
 
     def handlePageStarted(url : String)


### PR DESCRIPTION
Completes the JNIHelpers migration across the framework (continues #56, same direction as the original view/text_view/button/seek_bar refactor).

## Fixed in the android branches (most of this code had never been compiled — see the ci fix below)
- **sensors**: two double-comma syntax errors, `SesnorType::Gytoscope`/`Magnometer`/`Acclerometer` typos, wrong callback path (`com/native/`), `-> NIl` annotation, `delay_us` used without being a parameter
- **share**: `retun` typo, garbage putExtra signature `(Ljava/lang/string:ljava/lang/string:)`, `activity.class` on a Void*
- **toolbar**: `Menu.add` declared `(IIII)` but passed a jstring — JNI read the low 32 bits of the string pointer as a resource id; correct CharSequence overload now
- **biometric**: `BiometricPrompt` ctor looked up a ContextCompat signature (FragmentActivity is correct) → null method id → abort; executor/callback/prompt/builder refs leaked per call
- **permissions**: another double-comma, `nil` into `new_object_array`, per-call class/string ref leaks
- **scroll_view**: same local ref deleted twice; half-migration completed
- **image_view/edit_text/spinner/web_view/card_view/linear_layout/recycler_view/toast/alert_dialog/clipboard/connectivity/image_picker/location/camera/video/animation**: migrated to `JNIHelpers` (with_env/with_class/with_jstring/call_void_string/new_widget/new_callback/new_dialog_callback) — per-call local-ref leaks eliminated; method surfaces verified identical by diff

## JNIHelpers additions
`call_boolean`, `call_long`, `call_double`, `call_string`, `call_static_int/boolean/float`, `new_dialog_callback` (JI ctor).

## CI
- `-D` flags were placed AFTER the source path — passed to the program as argv, silently ignored; android/ios typechecks compiled desktop code only. Fixed: flags precede the source path, so platform branches get real type coverage from now on.
- Branch filters repaired (`ain, develop]` → `[main, develop]`).

## Remaining (deliberate, next batch)
media/audio (78 call sites), storage (160), platform, network android path, notifications, payment — being migrated in the same style.
