### PR TITLE
chore: release v0.1.7

### DIFF
--- a/src/native.cr
+++ b/src/native.cr
@@ -38,7 +38,7 @@ require "./native/framework/navigation/navigator"
 require "./native/framework/navigation/toolbar"
 
 module Native
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 
   def self.run
     args = ARGV


### PR DESCRIPTION
Bumps Native::VERSION to 0.1.7 for the release tag. Content ships via #55, #56, #57.